### PR TITLE
Previous commit results in a runtime error when the service is started

### DIFF
--- a/src/Topshelf/TopshelfDispatcher.cs
+++ b/src/Topshelf/TopshelfDispatcher.cs
@@ -24,16 +24,16 @@ namespace Topshelf
 
         public static void Dispatch(RunConfiguration config, TopshelfArguments args)
         {
-            //find the command by the args 'Command'
-            var run = new RunCommand(config.Coordinator, config.WinServiceSettings.ServiceName);
-
-			if(!string.IsNullOrEmpty(args.Instance))
+            if (!string.IsNullOrEmpty(args.Instance))
             {
                 _log.Info("Using instance name from commandline.");
                 config.WinServiceSettings.ServiceName = new ServiceName(
                     config.WinServiceSettings.ServiceName.Name,
                     args.Instance);
             }
+
+            //find the command by the args 'Command'
+            var run = new RunCommand(config.Coordinator, config.WinServiceSettings.ServiceName);
 
             var command = new List<Command>
                                   {


### PR DESCRIPTION
Previous commit results in a runtime error when the service is started. The commandline processing occured after the default run command was created. Resulting the service instance to be installed and uninstalled correctly but a non starting instance.

I somehow did not commit that change and found the error after I pulled the code today at another machine.

Please pull this change so that the service will run correctly.
