### PR TITLE
Support .Net 4.0 services by compiling the Host with .Net 4.0 Framework.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Apache 2.0 - see LICENSE
 # IMPORTANT
 NOTE: If you are looking at the source - please run build.bat before opening the solution. It creates the SolutionVersion.cs file that is necessary for a successful build.
 
-# INFO
 ## Overview
+# INFO
 Topshelf is an awesome service host for windows services.
 
 ## Getting started with Mass Topshelf
@@ -22,17 +22,26 @@ Topshelf is an awesome service host for windows services.
  1. Clone the source down to your machine. 
    `git clone git://github.com/Topshelf/Topshelf.git`
 2. Run `build.bat`. NOTE: You must have git on the path (open a regular command line and type git).
+3. If you want to edit the project in 4.0 mode you will have to edit all .csproj files at the top of the files, where it says:
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v3.5</TargetFrameworkVersion> 
+   or alternatively
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
+   depending on whose copy you've cloned. Edit it to match your preferred mode of coding in Visual Studio.
+   
+   Furthermore, you can edit rakefile.rb and set BUILD_CONFIG_KEY appropriately, to either NET40 or NET35.
+   Finally, changing it while using R# might cause cache corruption, and so you'd have to delete the _ReSharper
+   folder in your project in order to get solution-wide analysis going again.
 
 ### Contributing 
 
 1. `git config --global core.autoclrf false`
-2. Shared ReSharper settings are under src/Topshelf.resharper.xml for formatting and style
+2. Shared ReSharper settings are under src/Topshelf.resharper.xml for formatting and style. ReSharper should pick up on this automatically when you launch Visual Studio.
 3. Make a pull request
 
     
 # REQUIREMENTS
 * .NET Framework 3.5 
-
+* It isn't yet capable of hosting .Net Framework 4.0 Applications.
 
 # CREDITS
 Logo Design by [The Agile Badger](http://www.theagilebadger.com)  

--- a/build_support/BuildUtils.rb
+++ b/build_support/BuildUtils.rb
@@ -8,6 +8,7 @@ class NUnitRunner
 		@resultsDir = paths.fetch(:results, 'results')
 		@compilePlatform = paths.fetch(:platform, '')
 		@compileTarget = paths.fetch(:compilemode, 'debug')
+		@framework = paths.fetch(:target_framework_version, 'v4.0')
 	
 		@nunitExe = File.join('lib', 'nunit', 'net-2.0', "nunit-console#{(@compilePlatform.empty? ? '' : "-#{@compilePlatform}")}.exe").gsub('/','\\') + ' /nothread'
 	end
@@ -17,7 +18,7 @@ class NUnitRunner
 		
 		assemblies.each do |assem|
 			file = File.expand_path("#{@sourceDir}/#{assem}/bin/#{@compileTarget}/#{assem}.dll")
-			sh "#{@nunitExe} \"#{file}\""
+			sh "#{@nunitExe} \"#{file}\" /framework=#{@framework}"
 		end
 	end
 end

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -10,12 +10,17 @@ PRODUCT = "Topshelf"
 COPYRIGHT = 'Copyright 2007-2011 Travis Smith, Chris Patternson, Dru Sellers, et al. All rights reserved.';
 COMMON_ASSEMBLY_INFO = 'src/CommonAssemblyInfo.cs';
 CLR_TOOLS_VERSION = "v4.0.30319"
+# Either "NET35" or "NET40".
+BUILD_CONFIG_KEY = "NET40"
 
 props = { 
     :stage => File.expand_path("build_output"),
     :stage_merged => File.expand_path("build_merged"), 
-    :artifacts => File.expand_path("build_artifacts") 
+    :artifacts => File.expand_path("build_artifacts"),
+	:target_framework_version => (BUILD_CONFIG_KEY == "NET40" ? "v4.0" : "v3.5")
 }
+
+ 
 
 desc "Displays a list of tasks"
 task :help do
@@ -83,7 +88,11 @@ end
 
 desc "Compiles the app"
 task :compile => [:clean, :version] do
-  MSBuildRunner.compile :compilemode => COMPILE_TARGET, :solutionfile => 'src/Topshelf.sln', :clrversion => CLR_TOOLS_VERSION
+  MSBuildRunner.compile :compilemode => COMPILE_TARGET, 
+	:solutionfile => 'src/Topshelf.sln', 
+	:clrversion => CLR_TOOLS_VERSION,
+	:properties => ["BuildConfigKey=#{BUILD_CONFIG_KEY}", 
+					"TargetFrameworkVersion=#{props[:target_framework_version]}"]
   
   copyOutputFiles "bin/", "*.{dll,pdb}", props[:stage]
 end
@@ -99,7 +108,11 @@ task :test => [:unit_test]
 
 desc "Runs unit tests"
 task :unit_test => :compile do
-  runner = NUnitRunner.new :compilemode => COMPILE_TARGET, :source => 'src', :platform => 'x86'
+  runner = NUnitRunner.new :compilemode => COMPILE_TARGET, 
+	:source => 'src', 
+	:platform => 'x86',
+	:target_framework_version => props[:target_framework_version]
+	
   runner.executeTests ['Topshelf.Specs']
 end
 

--- a/src/Samples/Stuff/Stuff.csproj
+++ b/src/Samples/Stuff/Stuff.csproj
@@ -10,13 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Stuff</RootNamespace>
     <AssemblyName>Stuff</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/src/Samples/StuffOnAShelf/StuffOnAShelf.csproj
+++ b/src/Samples/StuffOnAShelf/StuffOnAShelf.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StuffOnAShelf</RootNamespace>
     <AssemblyName>StuffOnAShelf</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Topshelf.Host/Topshelf.Host.csproj
+++ b/src/Topshelf.Host/Topshelf.Host.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Topshelf</RootNamespace>
     <AssemblyName>Topshelf.Host</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/src/Topshelf.Specs/Topshelf.Specs.csproj
+++ b/src/Topshelf.Specs/Topshelf.Specs.csproj
@@ -10,13 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Topshelf.Specs</RootNamespace>
     <AssemblyName>Topshelf.Specs</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/src/Topshelf/Bottles/_About Bottles.txt
+++ b/src/Topshelf/Bottles/_About Bottles.txt
@@ -1,0 +1,5 @@
+﻿The messages are used by the service coordinators/controllers to control 
+the life-time. Messages are serializable (mostly).
+
+In general, if they use primitives, they are, otherwise they need to stay within this app domain in
+order not to cause cross-domain assembly loading. 

--- a/src/Topshelf/Messages/ContinueService.cs
+++ b/src/Topshelf/Messages/ContinueService.cs
@@ -12,6 +12,10 @@
 // specific language governing permissions and limitations under the License.
 namespace Topshelf.Messages
 {
+	using System;
+
+
+	[Serializable]
 	public class ContinueService :
 		ServiceCommand
 	{

--- a/src/Topshelf/Messages/CreateService.cs
+++ b/src/Topshelf/Messages/CreateService.cs
@@ -12,6 +12,10 @@
 // specific language governing permissions and limitations under the License.
 namespace Topshelf.Messages
 {
+	using System;
+
+
+	[Serializable]
 	public class CreateService :
 		ServiceCommand
 	{

--- a/src/Topshelf/Messages/ServiceCommand.cs
+++ b/src/Topshelf/Messages/ServiceCommand.cs
@@ -12,6 +12,9 @@
 // specific language governing permissions and limitations under the License.
 namespace Topshelf.Messages
 {
+	using System;
+
+	[Serializable]
 	public abstract class ServiceCommand
 	{
 		protected ServiceCommand(string serviceName)

--- a/src/Topshelf/Messages/_About Messages.txt
+++ b/src/Topshelf/Messages/_About Messages.txt
@@ -1,0 +1,5 @@
+﻿The messages are used by the service coordinators/controllers to control 
+the life-time. Messages are serializable (mostly).
+
+In general, if they use primitives, they are, otherwise they need to stay within this app domain in
+order not to cause cross-domain assembly loading. 

--- a/src/Topshelf/Topshelf.csproj
+++ b/src/Topshelf/Topshelf.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Topshelf</RootNamespace>
     <AssemblyName>Topshelf</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -41,6 +41,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -262,7 +263,10 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="Bottles\_About Bottles.txt" />
+    <Content Include="Messages\_About Messages.txt" />
+  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Dashboard\views\dashboard.html" />
   </ItemGroup>


### PR DESCRIPTION
See the discussion at http://groups.google.com/group/topshelf-discuss/browse_thread/thread/f484f557b1042261/48e53030a3cb1c11

I'm not compiling for .Net 4.0 by default in visual studio and with the rake file. I haven't tried anything at all with uppercut (all that xml... :s). Nor have I actually tested this with hosted services, relying on the 9 (!) unit tests to do that for me.
