### PR TITLE
Removed dependency on log4net from main TopShelf nuspec.

### DIFF
--- a/Topshelf.nuspec
+++ b/Topshelf.nuspec
@@ -9,9 +9,6 @@
 	<iconUrl>http://topshelf-project.com/wp-content/themes/pandora/img/slide.1.png</iconUrl>
     <licenseUrl>https://github.com/Topshelf/Topshelf/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Topshelf/Topshelf</projectUrl>
-    <dependencies>
-      <dependency id="log4net" version="1.2.11" />
-    </dependencies>
   </metadata>
   <files>
     <file src="build_output\NET35\Topshelf.dll" target="lib\NET35" />


### PR DESCRIPTION
As I understand things now, TopShelf doesn't have a hard dependency on any particular logging framework. We are using NLog in our project but when we NuGet in TopShelf it still pulls in log4net because of the declared dependency in the nuspec file.
