### PR TITLE
Spaces

### DIFF
--- a/src/Topshelf/Hosts/AbstractInstallerHost.cs
+++ b/src/Topshelf/Hosts/AbstractInstallerHost.cs
@@ -106,13 +106,13 @@ namespace Topshelf.Hosts
 			string arguments = " ";
 
 			if (_description.InstanceName.IsNotEmpty())
-				arguments += " -instance:{0}".FormatWith(_description.InstanceName);
+				arguments += " -instance \"{0}\"".FormatWith(_description.InstanceName);
 
             if (_description.DisplayName.IsNotEmpty())
                 arguments += " -displayname \"{0}\"".FormatWith(_description.DisplayName);
 
             if (_description.Name.IsNotEmpty())
-                arguments += " -servicename:{0}".FormatWith(_description.Name);
+                arguments += " -servicename \"{0}\"".FormatWith(_description.Name);
 
 			var installer = new HostInstaller(_description, arguments, installers);
 


### PR DESCRIPTION
This relates to issue #93 where it was discovered we weren't quoting
the instance name or service name of the parameters passed to
us from the command line. This quotes those values that are passed to
the lib.
