### PR TITLE
Feature log4net 1.2.10 provider

### DIFF
--- a/Topshelf.Log4Net.1.2.10.nuspec
+++ b/Topshelf.Log4Net.1.2.10.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Topshelf.Log4Net-1.2.10</id>
+    <version>2.3.0.0</version>
+    <authors>Chris Patterson, Dru Sellers, Travis Smith</authors>
+    <description>Integration library adding support for log4net 1.2.10 to Topshelf. Topshelf is a service library and hosting framework for .NET</description>
+    <language>en-US</language>
+	<iconUrl>http://topshelf-project.com/wp-content/themes/pandora/img/slide.1.png</iconUrl>
+    <licenseUrl>https://github.com/Topshelf/Topshelf/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Topshelf/Topshelf</projectUrl>
+    <dependencies>
+      <dependency id="log4net" version="1.2.10" />
+      <dependency id="Topshelf" version="2.3.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="build_output\NET35\Topshelf.Log4NetIntegration.1.2.10.dll" target="lib\NET35" />
+    <file src="build_output\NET35\Topshelf.Log4NetIntegration.1.2.10.xml" target="lib\NET35" />
+    <file src="build_output\NET35\Topshelf.Log4NetIntegration.1.2.10.pdb" target="lib\NET35" />
+    <file src="build_output\NET40\Topshelf.Log4NetIntegration.1.2.10.dll" target="lib\NET40" />
+    <file src="build_output\NET40\Topshelf.Log4NetIntegration.1.2.10.xml" target="lib\NET40" />
+    <file src="build_output\NET40\Topshelf.Log4NetIntegration.1.2.10.pdb" target="lib\NET40" />
+  </files>
+</package>
+

--- a/Topshelf.nuspec
+++ b/Topshelf.nuspec
@@ -9,9 +9,6 @@
 	<iconUrl>http://topshelf-project.com/wp-content/themes/pandora/img/slide.1.png</iconUrl>
     <licenseUrl>https://github.com/Topshelf/Topshelf/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Topshelf/Topshelf</projectUrl>
-    <dependencies>
-      <dependency id="log4net" version="1.2.11" />
-    </dependencies>
   </metadata>
   <files>
     <file src="build_output\NET35\Topshelf.dll" target="lib\NET35" />

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -105,6 +105,7 @@ task :compile => [:global_version, :build] do
 	copyOutputFiles File.join(props[:src], "Topshelf.Host/bin/#{BUILD_CONFIG}"), "log4net.{dll,pdb,xml,config}", props[:output]
 	copyOutputFiles File.join(props[:src], "Topshelf.Host/bin/#{BUILD_CONFIG}"), "Topshelf.Host.{exe,pdb}", props[:output]
 	copyOutputFiles File.join(props[:src], "Loggers/Topshelf.Log4NetIntegration/bin/#{BUILD_CONFIG}"), "Topshelf.Log4NetIntegration.{dll,xml,pdb}", props[:output]
+	copyOutputFiles File.join(props[:src], "Loggers/Topshelf.Log4NetIntegration.1.2.10/bin/#{BUILD_CONFIG}"), "Topshelf.Log4NetIntegration.1.2.10.{dll,xml,pdb}", props[:output]
 	copyOutputFiles File.join(props[:src], "Loggers/Topshelf.NLogIntegration/bin/#{BUILD_CONFIG}"), "Topshelf.NLogIntegration.{dll,xml,pdb}", props[:output]
 	copyOutputFiles File.join(props[:src], "Topshelf.Host/bin/#{BUILD_CONFIG}"), "Topshelf.Host.exe.config", props[:output]
 	copy(File.join(props[:src], "Topshelf.Host/bin/#{BUILD_CONFIG}-x86/Topshelf.Host.exe"), File.join(props[:output], 'Topshelf.Host-x86.exe'))
@@ -144,6 +145,7 @@ task :build => [:build_ts, :ilmerge, :copyloggers, :build_host, :build_x86]
 
 task :copyloggers do
 	copyOutputFiles File.join(props[:src], "Loggers/Topshelf.Log4NetIntegration/bin/#{BUILD_CONFIG}"), "Topshelf.Log4NetIntegration.{dll,xml,pdb}", props[:output]
+	copyOutputFiles File.join(props[:src], "Loggers/Topshelf.Log4NetIntegration.1.2.10/bin/#{BUILD_CONFIG}"), "Topshelf.Log4NetIntegration.1.2.10.{dll,xml,pdb}", props[:output]
 	copyOutputFiles File.join(props[:src], "Loggers/Topshelf.NLogIntegration/bin/#{BUILD_CONFIG}"), "Topshelf.NLogIntegration.{dll,xml,pdb}", props[:output]
 end
 
@@ -238,6 +240,7 @@ task :nuget do
 	sh "lib/nuget pack topshelf.nuspec /OutputDirectory build_artifacts"
 	sh "lib/nuget pack topshelf.dashboard.nuspec /OutputDirectory build_artifacts"
 	sh "lib/nuget pack topshelf.log4net.nuspec /OutputDirectory build_artifacts"
+	sh "lib/nuget pack topshelf.log4net.1.2.10.nuspec /OutputDirectory build_artifacts"
 	sh "lib/nuget pack topshelf.nlog.nuspec /OutputDirectory build_artifacts"
 end
 

--- a/src/Loggers/Topshelf.Log4NetIntegration.1.2.10/Properties/AssemblyInfo.cs
+++ b/src/Loggers/Topshelf.Log4NetIntegration.1.2.10/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Topshelf.Log4NetIntegration")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Topshelf.Log4NetIntegration")]
+[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("42d6f769-a0fb-4498-88f8-5d97af6fc67b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Loggers/Topshelf.Log4NetIntegration.1.2.10/Topshelf.Log4NetIntegration.1.2.10.csproj
+++ b/src/Loggers/Topshelf.Log4NetIntegration.1.2.10/Topshelf.Log4NetIntegration.1.2.10.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Topshelf</RootNamespace>
-    <AssemblyName>Topshelf.Log4NetIntegration</AssemblyName>
+    <AssemblyName>Topshelf.Log4NetIntegration.1.2.10</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -31,11 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net" Condition="'$(TargetFrameworkVersion)' == 'v3.5'">
-      <HintPath>..\..\..\lib\log4net\2.0.0\net35-full\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="log4net" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
-      <HintPath>..\..\..\lib\log4net\2.0.0\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net">
+      <HintPath>..\..\..\lib\log4net\1.2.10\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Topshelf.Host/Topshelf.Host.csproj
+++ b/src/Topshelf.Host/Topshelf.Host.csproj
@@ -88,10 +88,10 @@
   </PropertyGroup>
   <ItemGroup>
 	<Reference Include="log4net" Condition="'$(TargetFrameworkVersion)' == 'v3.5'">
-      <HintPath>..\..\lib\log4net\net35-full\log4net.dll</HintPath>
+      <HintPath>..\..\lib\log4net\2.0.0\net35-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="log4net" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
-      <HintPath>..\..\lib\log4net\net40-full\log4net.dll</HintPath>
+      <HintPath>..\..\lib\log4net\2.0.0\net40-full\log4net.dll</HintPath>
     </Reference>
      <Reference Include="Topshelf" Condition="'$(TargetFrameworkVersion)' == 'v3.5'">
       <HintPath>..\..\build_output\net35\Topshelf.dll</HintPath>

--- a/src/Topshelf.sln
+++ b/src/Topshelf.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.Log4NetIntegration
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.NLogIntegration", "Loggers\Topshelf.NLogIntegration\Topshelf.NLogIntegration.csproj", "{48948BF0-56FB-4139-839C-0F0143DF38C8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.Log4NetIntegration.1.2.10", "Loggers\Topshelf.Log4NetIntegration.1.2.10\Topshelf.Log4NetIntegration.1.2.10.csproj", "{F6B84B21-F881-4491-BD3F-DF7E55E0D609}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +95,16 @@ Global
 		{48948BF0-56FB-4139-839C-0F0143DF38C8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{48948BF0-56FB-4139-839C-0F0143DF38C8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{48948BF0-56FB-4139-839C-0F0143DF38C8}.Release|x86.ActiveCfg = Release|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -102,5 +114,6 @@ Global
 		{6C0B10B8-259E-4A1B-8415-4343F0B77054} = {4D6049C9-10B8-45D6-8E60-3A6DDBFF4E08}
 		{709D3896-BE22-423F-81E9-F557559E45F0} = {2B508B0F-88FB-4E29-82A4-3B6C84FB3425}
 		{48948BF0-56FB-4139-839C-0F0143DF38C8} = {2B508B0F-88FB-4E29-82A4-3B6C84FB3425}
+		{F6B84B21-F881-4491-BD3F-DF7E55E0D609} = {2B508B0F-88FB-4E29-82A4-3B6C84FB3425}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Removed main package nuget dependency on log4net 1.2.11.
- Created additional log4net 1.2.10 logging provider

I am having trouble with the framework 4 build of topshelf.host - it complains it can't find the DLL for dashboard (despite it being there and building just fine in VS). Any advice/assistance offered would be gratefully received  ;)
