### PR TITLE
Support for Install Before/After Rollback

### DIFF
--- a/src/SolutionVersion.cs
+++ b/src/SolutionVersion.cs
@@ -4,10 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Topshelf is an open source project for hosting services without friction. By referencing Topshelf, your console application *becomes* a service installer with a comprehensive set of command-line options for installing, configuring, and running your application as a service.")]
 [assembly: AssemblyProduct("Topshelf")]
 [assembly: AssemblyCopyright("Copyright 2012 Chris Patterson, Dru Sellers, Travis Smith, All rights reserved.")]
-[assembly: AssemblyVersion("3.0.3")]
-[assembly: AssemblyFileVersion("3.0.3")]
+[assembly: AssemblyVersion("3.1.0")]
+[assembly: AssemblyFileVersion("3.1.0")]
 
-[assembly: AssemblyInformationalVersion("3.0.3.5e5113")]
+[assembly: AssemblyInformationalVersion("3.1.0.000000")]
 [assembly: ComVisibleAttribute(false)]
 [assembly: CLSCompliantAttribute(true)]
-

--- a/src/Topshelf/Configuration/Builders/InstallBuilder.cs
+++ b/src/Topshelf/Configuration/Builders/InstallBuilder.cs
@@ -26,6 +26,8 @@ namespace Topshelf.Builders
         readonly HostEnvironment _environment;
         readonly IList<Action<InstallHostSettings>> _postActions;
         readonly IList<Action<InstallHostSettings>> _preActions;
+        readonly IList<Action<InstallHostSettings>> _postRollbackActions;
+        readonly IList<Action<InstallHostSettings>> _preRollbackActions;
         readonly HostSettings _settings;
         Credentials _credentials;
         HostStartMode _startMode;
@@ -35,6 +37,8 @@ namespace Topshelf.Builders
         {
             _preActions = new List<Action<InstallHostSettings>>();
             _postActions = new List<Action<InstallHostSettings>>();
+            _preRollbackActions = new List<Action<InstallHostSettings>>();
+            _postRollbackActions = new List<Action<InstallHostSettings>>();
             _dependencies = new List<string>();
             _startMode = HostStartMode.Automatic;
             _credentials = new Credentials("", "", ServiceAccount.LocalSystem);
@@ -56,7 +60,7 @@ namespace Topshelf.Builders
         public Host Build(ServiceBuilder serviceBuilder)
         {
             return new InstallHost(_environment, _settings, _startMode, _dependencies.ToArray(), _credentials,
-                _preActions, _postActions, _sudo);
+                _preActions, _postActions, _preRollbackActions, _postRollbackActions, _sudo);
         }
 
         public void Match<T>(Action<T> callback)
@@ -95,6 +99,16 @@ namespace Topshelf.Builders
         public void AfterInstall(Action<InstallHostSettings> callback)
         {
             _postActions.Add(callback);
+        }
+
+        public void BeforeRollback(Action<InstallHostSettings> callback)
+        {
+            _preRollbackActions.Add(callback);
+        }
+
+        public void AfterRollback(Action<InstallHostSettings> callback)
+        {
+            _postRollbackActions.Add(callback);
         }
 
         public void AddDependency(string name)

--- a/src/Topshelf/Configuration/InstallHostConfiguratorExtensions.cs
+++ b/src/Topshelf/Configuration/InstallHostConfiguratorExtensions.cs
@@ -62,5 +62,51 @@ namespace Topshelf
 
             return configurator;
         }
+
+        public static HostConfigurator BeforeRollback(this HostConfigurator configurator, Action callback)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException("configurator");
+
+            configurator.AddConfigurator(new InstallHostConfiguratorAction("BeforeRollback",
+                x => x.BeforeRollback(settings => callback())));
+
+            return configurator;
+        }
+
+        public static HostConfigurator BeforeRollback(this HostConfigurator configurator,
+            Action<InstallHostSettings> callback)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException("configurator");
+
+            configurator.AddConfigurator(new InstallHostConfiguratorAction("BeforeRollback",
+                x => x.BeforeRollback(callback)));
+
+            return configurator;
+        }
+
+        public static HostConfigurator AfterRollback(this HostConfigurator configurator, Action callback)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException("configurator");
+
+            configurator.AddConfigurator(new InstallHostConfiguratorAction("AfterRollback",
+                x => x.AfterRollback(settings => callback())));
+
+            return configurator;
+        }
+
+        public static HostConfigurator AfterRollback(this HostConfigurator configurator,
+            Action<InstallHostSettings> callback)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException("configurator");
+
+            configurator.AddConfigurator(new InstallHostConfiguratorAction("AfterRollback", 
+                x => x.AfterRollback(callback)));
+
+            return configurator;
+        }
     }
 }

--- a/src/Topshelf/Runtime/HostEnvironment.cs
+++ b/src/Topshelf/Runtime/HostEnvironment.cs
@@ -57,8 +57,10 @@ namespace Topshelf.Runtime
         /// <param name="settings"></param>
         /// <param name="beforeInstall"> </param>
         /// <param name="afterInstall"> </param>
-        void InstallService(InstallHostSettings settings, Action beforeInstall, Action afterInstall);
-        
+        /// <param name="beforeRollback"> </param>
+        /// <param name="afterRollback"> </param>
+        void InstallService(InstallHostSettings settings, Action beforeInstall, Action afterInstall, Action beforeRollback, Action afterRollback);
+
         /// <summary>
         /// Uninstall the service using the settings provided
         /// </summary>

--- a/src/Topshelf/Runtime/Windows/HostServiceInstaller.cs
+++ b/src/Topshelf/Runtime/Windows/HostServiceInstaller.cs
@@ -51,12 +51,16 @@ namespace Topshelf.Runtime.Windows
             }
         }
 
-        public void InstallService(Action<InstallEventArgs> beforeInstall, Action<InstallEventArgs> afterInstall)
+        public void InstallService(Action<InstallEventArgs> beforeInstall, Action<InstallEventArgs> afterInstall, Action<InstallEventArgs> beforeRollback, Action<InstallEventArgs> afterRollback)
         {
             if (beforeInstall != null)
                 _installer.BeforeInstall += (sender, args) => beforeInstall(args);
             if (afterInstall != null)
                 _installer.AfterInstall += (sender, args) => afterInstall(args);
+            if (beforeRollback != null)
+                _installer.BeforeRollback += (sender, args) => beforeRollback(args);
+            if (afterRollback != null)
+                _installer.AfterRollback += (sender, args) => afterRollback(args);
 
             Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
 
@@ -125,7 +129,7 @@ namespace Topshelf.Runtime.Windows
                 throw new TopshelfException("Assembly.GetEntryAssembly() is null for some reason.");
 
             string path = string.Format("/assemblypath={0}", assembly.Location);
-            string[] commandLine = {path};
+            string[] commandLine = { path };
 
             var context = new InstallContext(null, commandLine);
             transactedInstaller.Context = context;

--- a/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
@@ -164,7 +164,7 @@ namespace Topshelf.Runtime.Windows
             return new WindowsServiceHost(this, settings, serviceHandle);
         }
 
-        public void InstallService(InstallHostSettings settings, Action beforeInstall, Action afterInstall)
+        public void InstallService(InstallHostSettings settings, Action beforeInstall, Action afterInstall, Action beforeRollback, Action afterRollback)
         {
             using (var installer = new HostServiceInstaller(settings))
             {
@@ -180,7 +180,19 @@ namespace Topshelf.Runtime.Windows
                             afterInstall();
                     };
 
-                installer.InstallService(before, after);
+                Action<InstallEventArgs> before2 = x =>
+                    {
+                        if (beforeRollback != null)
+                            beforeRollback();
+                    };
+
+                Action<InstallEventArgs> after2 = x =>
+                    {
+                        if (afterRollback != null)
+                            afterRollback();
+                    };
+
+                installer.InstallService(before, after, before2, after2);
             }
         }
 


### PR DESCRIPTION
My new job wants access to the Before/After Rollback installer events so I've added them to the repo. It'd be great if you could incorporate them into the main branch so the features would be available thru NuGet. If this pull request isn't satisfactory let me know if there's anything I can do or add to get it accepted.
