### PR TITLE
Adding Elmah logging project as an alternative logging option

### DIFF
--- a/src/Topshelf.Elmah/ElmahConfigurationExtensions.cs
+++ b/src/Topshelf.Elmah/ElmahConfigurationExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2007-2012 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Topshelf
+{
+    using HostConfigurators;
+    using Logging;
+
+    /// <summary>
+    ///   Extensions for configuring Logging for log4net
+    /// </summary>
+    public static class ElmahConfigurationExtensions
+    {
+        /// <summary>
+        ///   Specify that you want to use the Elmah logging engine.
+        /// </summary>
+        /// <param name="configurator"> </param>
+        public static void UseElmah(this HostConfigurator configurator)
+        {
+            ElmahLogWriterFactory.Use();
+        }
+    }
+}

--- a/src/Topshelf.Elmah/Logging/ElmahLogWriter.cs
+++ b/src/Topshelf.Elmah/Logging/ElmahLogWriter.cs
@@ -1,0 +1,343 @@
+// Copyright 2007-2011 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Topshelf.Logging
+{
+    using System;
+    using System.Globalization;
+    using Elmah;
+    using Topshelf.Logging;
+
+    public class ElmahLogLevels
+    {
+        public bool IsDebugEnabled { get; set; }
+        public bool IsInfoEnabled { get; set; }
+        public bool IsWarnEnabled { get; set; }
+        public bool IsErrorEnabled { get; set; }
+        public bool IsFatalEnabled { get; set; }
+    }
+
+    public enum ElmahLogLevelsEnum
+    {
+        Debug,
+        Info,
+        Warn,
+        Error,
+        Fatal
+    }
+
+    public class ElmahLogWriter :
+        LogWriter
+    {
+        private readonly ErrorLog _log;
+        private readonly ElmahLogLevels _logLevels;
+
+        public ElmahLogWriter()
+            : this(ErrorLog.GetDefault(null), null)
+        { }
+
+        public ElmahLogWriter(ElmahLogLevels logLevels)
+            : this(ErrorLog.GetDefault(null), logLevels)
+        { }
+
+        public ElmahLogWriter(ErrorLog log, ElmahLogLevels logLevels)
+        {
+            _log = log;
+            _logLevels = logLevels ?? new ElmahLogLevels()
+            {
+                IsDebugEnabled = true,
+                IsErrorEnabled = true,
+                IsFatalEnabled = true,
+                IsInfoEnabled = true,
+                IsWarnEnabled = true
+            };
+        }
+
+        private void WriteToElmah(ElmahLogLevelsEnum logLevel, LogWriterOutputProvider messageProvider)
+        {
+            WriteToElmah(logLevel, messageProvider().ToString());
+        }
+
+        private void WriteToElmah(ElmahLogLevelsEnum logLevel, string format, params object[] args)
+        {
+            WriteToElmah(logLevel, String.Format(format, args));
+        }
+
+        private void WriteToElmah(ElmahLogLevelsEnum logLevel, string message, Exception exception = null)
+        {
+            var error = exception == null ? new Error() : new Error(exception);
+            var type = error.Exception != null ? error.Exception.GetType().FullName : GetLogLevel(logLevel);
+            error.Type = type;
+            error.Message = message;
+            error.Time = DateTime.Now;
+            error.HostName = Environment.MachineName;
+            error.Detail = exception == null ? message : exception.StackTrace;
+
+            _log.Log(error);
+        }
+
+        private string GetLogLevel(ElmahLogLevelsEnum logLevel)
+        {
+            switch (logLevel)
+            {
+                case ElmahLogLevelsEnum.Debug:
+                    return "Debug";
+                case ElmahLogLevelsEnum.Info:
+                    return "Info";
+                case ElmahLogLevelsEnum.Warn:
+                    return "Warn";
+                case ElmahLogLevelsEnum.Error:
+                    return "Error";
+                case ElmahLogLevelsEnum.Fatal:
+                    return "Fatal";
+            }
+
+            return "unknown log level";
+        }
+
+        
+        public void Debug(object message)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Debug, message.ToString());
+        }
+
+        public void Debug(object message, Exception exception)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Debug, message.ToString(), exception);
+        }
+
+        public void Debug(LogWriterOutputProvider messageProvider)
+        {
+            if (!IsDebugEnabled)
+                return;
+
+            WriteToElmah(ElmahLogLevelsEnum.Debug, messageProvider);
+        }
+
+        public void DebugFormat(string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Debug, format, args);
+        }
+
+        public void DebugFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Debug, format, args);
+        }
+
+        public void Info(object message)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Info, message.ToString());
+        }
+
+        public void Info(object message, Exception exception)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Info, message.ToString(), exception);
+        }
+
+        public void Info(LogWriterOutputProvider messageProvider)
+        {
+            if (!IsInfoEnabled)
+                return;
+
+            WriteToElmah(ElmahLogLevelsEnum.Info, messageProvider);
+        }
+
+        public void InfoFormat(string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Info, format, args);
+        }
+
+        public void InfoFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Info, format, args);
+        }
+
+        public void Warn(object message)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Warn, message.ToString());
+        }
+
+        public void Warn(object message, Exception exception)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Warn, message.ToString(), exception);
+        }
+
+        public void Warn(LogWriterOutputProvider messageProvider)
+        {
+            if (!IsWarnEnabled)
+                return;
+
+            WriteToElmah(ElmahLogLevelsEnum.Warn, messageProvider);
+        }
+
+        public void WarnFormat(string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Warn, format, args);
+        }
+
+        public void WarnFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Warn, format, args);
+        }
+
+        public void Error(object message)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Error, message.ToString());
+        }
+
+        public void Error(object message, Exception exception)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Error, message.ToString(), exception);
+        }
+
+        public void Error(LogWriterOutputProvider messageProvider)
+        {
+            if (!IsErrorEnabled)
+                return;
+
+            WriteToElmah(ElmahLogLevelsEnum.Error, messageProvider);
+        }
+
+        public void ErrorFormat(string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Error, format, args);
+        }
+
+        public void ErrorFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Error, format, args);
+        }
+
+        public void Fatal(object message)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Fatal, message.ToString());
+        }
+
+        public void Fatal(object message, Exception exception)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Fatal, message.ToString(), exception);
+        }
+
+        public void Fatal(LogWriterOutputProvider messageProvider)
+        {
+            if (!IsFatalEnabled)
+                return;
+            
+            WriteToElmah(ElmahLogLevelsEnum.Fatal, messageProvider);
+        }
+
+        public void FatalFormat(string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Fatal, format, args);
+        }
+
+        public void FatalFormat(IFormatProvider provider, string format, params object[] args)
+        {
+            WriteToElmah(ElmahLogLevelsEnum.Fatal, format, args);
+        }
+
+        public bool IsDebugEnabled
+        {
+            get { return _logLevels.IsDebugEnabled; }
+        }
+
+        public bool IsInfoEnabled
+        {
+            get { return _logLevels.IsInfoEnabled; }
+        }
+
+        public bool IsWarnEnabled
+        {
+            get { return _logLevels.IsWarnEnabled; }
+        }
+
+        public bool IsErrorEnabled
+        {
+            get { return _logLevels.IsErrorEnabled; }
+        }
+
+        public bool IsFatalEnabled
+        {
+            get { return _logLevels.IsFatalEnabled; }
+        }
+
+        public void Log(LoggingLevel level, object obj)
+        {
+            if (level == LoggingLevel.Fatal)
+                Fatal(obj);
+            else if (level == LoggingLevel.Error)
+                Error(obj);
+            else if (level == LoggingLevel.Warn)
+                Warn(obj);
+            else if (level == LoggingLevel.Info)
+                Info(obj);
+            else if (level >= LoggingLevel.Debug)
+                Debug(obj);
+        }
+
+        public void Log(LoggingLevel level, object obj, Exception exception)
+        {
+            if (level == LoggingLevel.Fatal)
+                Fatal(obj, exception);
+            else if (level == LoggingLevel.Error)
+                Error(obj, exception);
+            else if (level == LoggingLevel.Warn)
+                Warn(obj, exception);
+            else if (level == LoggingLevel.Info)
+                Info(obj, exception);
+            else if (level >= LoggingLevel.Debug)
+                Debug(obj, exception);
+        }
+
+        public void Log(LoggingLevel level, LogWriterOutputProvider messageProvider)
+        {
+            if (level == LoggingLevel.Fatal)
+                Fatal(messageProvider);
+            else if (level == LoggingLevel.Error)
+                Error(messageProvider);
+            else if (level == LoggingLevel.Warn)
+                Warn(messageProvider);
+            else if (level == LoggingLevel.Info)
+                Info(messageProvider);
+            else if (level >= LoggingLevel.Debug)
+                Debug(messageProvider);
+        }
+
+        public void LogFormat(LoggingLevel level, string format, params object[] args)
+        {
+            if (level == LoggingLevel.Fatal)
+                FatalFormat(CultureInfo.InvariantCulture, format, args);
+            else if (level == LoggingLevel.Error)
+                ErrorFormat(CultureInfo.InvariantCulture, format, args);
+            else if (level == LoggingLevel.Warn)
+                WarnFormat(CultureInfo.InvariantCulture, format, args);
+            else if (level == LoggingLevel.Info)
+                InfoFormat(CultureInfo.InvariantCulture, format, args);
+            else if (level >= LoggingLevel.Debug)
+                DebugFormat(CultureInfo.InvariantCulture, format, args);
+        }
+
+        public void LogFormat(LoggingLevel level, IFormatProvider formatProvider, string format, params object[] args)
+        {
+            if (level == LoggingLevel.Fatal)
+                FatalFormat(formatProvider, format, args);
+            else if (level == LoggingLevel.Error)
+                ErrorFormat(formatProvider, format, args);
+            else if (level == LoggingLevel.Warn)
+                WarnFormat(formatProvider, format, args);
+            else if (level == LoggingLevel.Info)
+                InfoFormat(formatProvider, format, args);
+            else if (level >= LoggingLevel.Debug)
+                DebugFormat(formatProvider, format, args);
+        }
+    }
+}

--- a/src/Topshelf.Elmah/Logging/ElmahLogWriterFactory.cs
+++ b/src/Topshelf.Elmah/Logging/ElmahLogWriterFactory.cs
@@ -1,0 +1,47 @@
+// Copyright 2007-2012 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Topshelf.Logging
+{
+    using System;
+    using Elmah;
+
+    public class ElmahLogWriterFactory :
+        LogWriterFactory
+    {
+        public LogWriter Get(string name)
+        {
+            return new ElmahLogWriter();
+        }
+
+        public void Shutdown()
+        {
+
+        }
+
+        public static void Use()
+        {
+            HostLogger.UseLogger(new ElmahHostLoggerConfigurator());
+        }
+
+
+        [Serializable]
+        public class ElmahHostLoggerConfigurator :
+            HostLoggerConfigurator
+        {
+            public LogWriterFactory CreateLogWriterFactory()
+            {
+                return new ElmahLogWriterFactory();
+            }
+        }
+    }
+}

--- a/src/Topshelf.Elmah/Topshelf.Elmah.csproj
+++ b/src/Topshelf.Elmah/Topshelf.Elmah.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B6990D65-5B8A-4332-B01F-DE60D7042F6E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Topshelf.Elmah</RootNamespace>
+    <AssemblyName>Topshelf.Elmah</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Elmah">
+      <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\SolutionVersion.cs">
+      <Link>SolutionVersion.cs</Link>
+    </Compile>
+    <Compile Include="ElmahConfigurationExtensions.cs" />
+    <Compile Include="Logging\ElmahLogWriter.cs" />
+    <Compile Include="Logging\ElmahLogWriterFactory.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Topshelf\Topshelf.csproj">
+      <Project>{a52ad64d-6455-4a22-8ccf-581851086578}</Project>
+      <Name>Topshelf</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Topshelf.Elmah/packages.config
+++ b/src/Topshelf.Elmah/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
+</packages>

--- a/src/Topshelf.sln
+++ b/src/Topshelf.sln
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E9335D
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.Elmah", "Topshelf.Elmah\Topshelf.Elmah.csproj", "{B6990D65-5B8A-4332-B01F-DE60D7042F6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -131,6 +133,16 @@ Global
 		{7EE5892C-6754-4DC4-95B6-123C9C86C740}.Release|Mixed Platforms.Build.0 = Release|x86
 		{7EE5892C-6754-4DC4-95B6-123C9C86C740}.Release|x86.ActiveCfg = Release|x86
 		{7EE5892C-6754-4DC4-95B6-123C9C86C740}.Release|x86.Build.0 = Release|x86
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B6990D65-5B8A-4332-B01F-DE60D7042F6E}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hi, 

After asking this question on stack overflow http://stackoverflow.com/questions/20618760/how-do-i-make-topshelf-log-exceptions-to-elmah I decided to add elmah as a logging option.  I've tested this locally and it's sending the correct logs to my elmah database when the service is created and when exceptions are thrown.

There's probably more that can be done here if someone only wanted specific logging levels but that's for another day I think.
