### PR TITLE
Fixed log message for processing custom command.

### DIFF
--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -242,7 +242,7 @@ namespace Topshelf.Runtime.Windows
 
                 _serviceHandle.CustomCommand(this, command);
 
-                _log.Info("[Topshelf] Custom command {0} processed");
+                _log.Info(string.Format("[Topshelf] Custom command {0} processed", command));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
After implementing and testing found quite stupid mistake: custom command was not string.Format'ted into log message. Does not affect any functionality except strange log message.
