### PR TITLE
Setting ServiceBase.ServiceName so fatal errors make it to the Event Log

### DIFF
--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -50,6 +50,7 @@ namespace Topshelf.Runtime.Windows
             CanPauseAndContinue = settings.CanPauseAndContinue;
             CanShutdown = settings.CanShutdown;
             CanHandleSessionChangeEvent = settings.CanSessionChanged;
+            ServiceName = _settings.ServiceName;
         }
 
         public TopshelfExitCode Run()
@@ -127,7 +128,6 @@ namespace Topshelf.Runtime.Windows
             catch (Exception ex)
             {
                 _log.Fatal("The service did not start successfully", ex);
-                _log.Fatal(ex);
 
                 ExitCode = (int)TopshelfExitCode.StartServiceFailed;
                 throw;


### PR DESCRIPTION
If it's not set, an ArgumentException is thrown when the service crashes and the original Exception is never logged in the Event Log.  From http://msdn.microsoft.com/en-us/library/vstudio/system.serviceprocess.servicebase.servicename.aspx

> The ServiceName is also used to specify the EventLog.Source associated with the EventLog property. This EventLog is an instance that writes service command information to the Application log.
> 
> The ServiceName, which supplies the source string for the event log, must be set before the service writes to the event log. Trying to access the event log before the source name is set causes an exception to be thrown.

I also removed the duplicate log statement in the catch block in OnStart.
