### PR TITLE
Update NLog to 3.1.0 and resolve "obsolete" warnings

### DIFF
--- a/src/Topshelf.NLog/Logging/NLogLogWriter.cs
+++ b/src/Topshelf.NLog/Logging/NLogLogWriter.cs
@@ -67,7 +67,7 @@ namespace Topshelf.Logging
 
         public void Log(LoggingLevel level, object obj, Exception exception)
         {
-            _log.LogException(GetNLogLevel(level), obj == null
+            _log.Log(GetNLogLevel(level), obj == null
                                                        ? ""
                                                        : obj.ToString(), exception);
         }
@@ -95,7 +95,7 @@ namespace Topshelf.Logging
 
         public void Debug(object obj, Exception exception)
         {
-            _log.LogException(LogLevel.Debug, obj == null
+            _log.Log(LogLevel.Debug, obj == null
                                                        ? ""
                                                        : obj.ToString(), exception);
         }
@@ -112,7 +112,7 @@ namespace Topshelf.Logging
 
         public void Info(object obj, Exception exception)
         {
-            _log.LogException(LogLevel.Info, obj == null
+            _log.Log(LogLevel.Info, obj == null
                                                       ? ""
                                                       : obj.ToString(), exception);
         }
@@ -129,7 +129,7 @@ namespace Topshelf.Logging
 
         public void Warn(object obj, Exception exception)
         {
-            _log.LogException(LogLevel.Warn, obj == null
+            _log.Log(LogLevel.Warn, obj == null
                                                       ? ""
                                                       : obj.ToString(), exception);
         }
@@ -146,7 +146,7 @@ namespace Topshelf.Logging
 
         public void Error(object obj, Exception exception)
         {
-            _log.LogException(LogLevel.Error, obj == null
+            _log.Log(LogLevel.Error, obj == null
                                                        ? ""
                                                        : obj.ToString(), exception);
         }
@@ -163,7 +163,7 @@ namespace Topshelf.Logging
 
         public void Fatal(object obj, Exception exception)
         {
-            _log.LogException(LogLevel.Fatal, obj == null
+            _log.Log(LogLevel.Fatal, obj == null
                                                        ? ""
                                                        : obj.ToString(), exception);
         }

--- a/src/Topshelf.NLog/Topshelf.NLog.csproj
+++ b/src/Topshelf.NLog/Topshelf.NLog.csproj
@@ -38,10 +38,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog" Condition="'$(TargetFrameworkVersion)' == 'v3.5'">
-      <HintPath>..\packages\NLog.2.1.0\lib\net35\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.3.1.0.0\lib\net35\NLog.dll</HintPath>
     </Reference>
     <Reference Include="NLog" Condition="'$(TargetFrameworkVersion)' != 'v3.5'">
-      <HintPath>..\packages\NLog.2.1.0\lib\net40\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.3.1.0.0\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Topshelf.NLog/packages.config
+++ b/src/Topshelf.NLog/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="2.1.0" targetFramework="net40" />
+  <package id="NLog" version="3.1.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Please merge these changes to make Topshelf work with the current version of NLog.
