### PR TITLE
Flush log buffers on unhandled exception

### DIFF
--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -144,6 +144,8 @@ namespace Topshelf.Hosts
         {
             _log.Fatal("The service threw an unhandled exception", (Exception)e.ExceptionObject);
 
+            HostLogger.Shutdown();
+
             if (e.IsTerminating)
             {
                 _exit.Set();

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -266,7 +266,9 @@ namespace Topshelf.Runtime.Windows
         void CatchUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
             _log.Fatal("The service threw an unhandled exception", (Exception)e.ExceptionObject);
-            
+
+            HostLogger.Shutdown();
+
 //            // IF not terminating, then no reason to stop the service?
 //            if (!e.IsTerminating)
 //                return;


### PR DESCRIPTION
Flush buffers on unhandled exception to log message in case of async logger.
Service crashes silently otherwise. This also closes #171 
