### PR TITLE
Mono runtime check on IsServiceInstalled method, returns false if Mono

### DIFF
--- a/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
@@ -30,6 +30,11 @@ namespace Topshelf.Runtime.Windows
 
         public bool IsServiceInstalled(string serviceName)
         {
+            if (Type.GetType("Mono.Runtime") != null)
+            {
+                return false;
+            }
+            
             return ServiceController.GetServices()
                 .Any(service => string.CompareOrdinal(service.ServiceName, serviceName) == 0);
         }


### PR DESCRIPTION
Very minor workaround but allows for TopShelf enabled exes to be executed in Linux without throwing a NotImplementedException.
