### PR TITLE
Return error code for unhandled exceptions when running under ConsoleHost

### DIFF
--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -34,6 +34,7 @@ namespace Topshelf.Hosts
         readonly HostSettings _settings;
         int _deadThread;
 
+        TopshelfExitCode _exitCode;
         ManualResetEvent _exit;
         volatile bool _hasCancelled;
 
@@ -85,6 +86,7 @@ namespace Topshelf.Hosts
                 _log.Debug("Starting up as a console application");
 
                 _exit = new ManualResetEvent(false);
+                _exitCode = TopshelfExitCode.Ok;
 
                 Console.Title = _settings.DisplayName;
                 Console.CancelKeyPress += HandleCancelKeyPress;
@@ -115,7 +117,7 @@ namespace Topshelf.Hosts
                 HostLogger.Shutdown();
             }
 
-            return TopshelfExitCode.Ok;
+            return _exitCode;
         }
 
 
@@ -146,6 +148,7 @@ namespace Topshelf.Hosts
 
             if (e.IsTerminating)
             {
+                _exitCode = TopshelfExitCode.UnhandledServiceException;
                 _exit.Set();
 
 #if !NET35


### PR DESCRIPTION
This makes the behaviour consistent with the WindowsServiceHost
