### PR TITLE
Add Support for Watching Log4Net Files

### DIFF
--- a/src/Topshelf.Log4Net/Log4NetConfigurationExtensions.cs
+++ b/src/Topshelf.Log4Net/Log4NetConfigurationExtensions.cs
@@ -38,5 +38,16 @@ namespace Topshelf
         {
             Log4NetLogWriterFactory.Use(configFileName);
         }
+
+        /// <summary>
+        ///   Specify that you want to use the Log4net logging engine.
+        /// </summary>
+        /// <param name="configurator"> </param>
+        /// <param name="configFileName"> The name of the log4net xml configuration file </param>
+        /// <param name="watchFile"> Should log4net watch the config file? </param>
+        public static void UseLog4Net(this HostConfigurator configurator, string configFileName, bool watchFile)
+        {
+            Log4NetLogWriterFactory.Use(configFileName, watchFile);
+        }
     }
 }

--- a/src/Topshelf.Log4Net/Logging/Log4NetLogWriterFactory.cs
+++ b/src/Topshelf.Log4Net/Logging/Log4NetLogWriterFactory.cs
@@ -40,15 +40,27 @@ namespace Topshelf.Logging
             HostLogger.UseLogger(new Log4NetLoggerConfigurator(file));
         }
 
+        public static void Use(string file, bool watch)
+        {
+            HostLogger.UseLogger(new Log4NetLoggerConfigurator(file, watch));
+        }
+
         [Serializable]
         public class Log4NetLoggerConfigurator :
             HostLoggerConfigurator
         {
             readonly string _file;
+            readonly bool _watch;
 
             public Log4NetLoggerConfigurator(string file)
+              : this(file, false)
+            {
+            }
+
+            public Log4NetLoggerConfigurator(string file, bool watch)
             {
                 _file = file;
+                _watch = watch;
             }
 
             public LogWriterFactory CreateLogWriterFactory()
@@ -59,7 +71,14 @@ namespace Topshelf.Logging
                     var configFile = new FileInfo(file);
                     if (configFile.Exists)
                     {
-                        XmlConfigurator.Configure(configFile);
+                        if (_watch)
+                        {
+                            XmlConfigurator.ConfigureAndWatch(configFile);
+                        }
+                        else
+                        {
+                            XmlConfigurator.Configure(configFile);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Log4net can be configured to watch the config file for changes and
re-load it witout stopping the applicaiton. This is quite useful for
services.

You can configure log4net to do this with assembly attributes or an
entry in the App.config file. This adds the ability to specify it in the
`.UseLog4Net` call too for ortogonality.