### PR TITLE
WindowsServiceHost will process service start arguments

### DIFF
--- a/src/Topshelf/Configuration/HostConfigurators/EnvironmentBuilderFactory.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/EnvironmentBuilderFactory.cs
@@ -14,5 +14,5 @@ namespace Topshelf.HostConfigurators
 {
     using Builders;
 
-    public delegate EnvironmentBuilder EnvironmentBuilderFactory();
+    public delegate EnvironmentBuilder EnvironmentBuilderFactory(HostConfigurator configurator);
 }

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -189,7 +189,7 @@ namespace Topshelf.HostConfigurators
                       .InfoFormat("{0} v{1}, .NET Framework v{2}", type.Namespace, type.Assembly.GetName().Version,
                           Environment.Version);
 
-            EnvironmentBuilder environmentBuilder = _environmentBuilderFactory();
+            EnvironmentBuilder environmentBuilder = _environmentBuilderFactory(this);
 
             HostEnvironment environment = environmentBuilder.Build();
 
@@ -224,9 +224,9 @@ namespace Topshelf.HostConfigurators
             return new RunBuilder(environment, settings);
         }
 
-        static EnvironmentBuilder DefaultEnvironmentBuilderFactory()
+        static EnvironmentBuilder DefaultEnvironmentBuilderFactory(HostConfigurator configurator)
         {
-            return new WindowsHostEnvironmentBuilder();
+            return new WindowsHostEnvironmentBuilder(configurator);
         }
     }
 }

--- a/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
@@ -22,11 +22,18 @@ namespace Topshelf.Runtime.Windows
     using System.Security.Principal;
     using System.ServiceProcess;
     using Logging;
+    using Topshelf.HostConfigurators;
 
     public class WindowsHostEnvironment :
         HostEnvironment
     {
         readonly LogWriter _log = HostLogger.Get(typeof(WindowsHostEnvironment));
+        private HostConfigurator _hostConfigurator;
+
+        public WindowsHostEnvironment(HostConfigurator configurator)
+        {
+            _hostConfigurator = configurator;
+        }
 
         public bool IsServiceInstalled(string serviceName)
         {
@@ -180,7 +187,7 @@ namespace Topshelf.Runtime.Windows
 
         public Host CreateServiceHost(HostSettings settings, ServiceHandle serviceHandle)
         {
-            return new WindowsServiceHost(this, settings, serviceHandle);
+            return new WindowsServiceHost(this, settings, serviceHandle, this._hostConfigurator);
         }
 
         public void SendServiceCommand(string serviceName, int command)

--- a/src/Topshelf/Runtime/Windows/WindowsHostEnvironmentBuilder.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostEnvironmentBuilder.cs
@@ -13,13 +13,21 @@
 namespace Topshelf.Runtime.Windows
 {
     using Builders;
+    using Topshelf.HostConfigurators;
 
     public class WindowsHostEnvironmentBuilder :
         EnvironmentBuilder
     {
+        HostConfigurator _hostConfigurator;
+
+        public WindowsHostEnvironmentBuilder(HostConfigurator configurator)
+        {
+            _hostConfigurator = configurator;
+        }
+
         public HostEnvironment Build()
         {
-            return new WindowsHostEnvironment();
+            return new WindowsHostEnvironment(_hostConfigurator);
         }
     }
 }

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -21,7 +21,7 @@ namespace Topshelf.Runtime.Windows
     using System.Threading.Tasks;
 #endif
     using Logging;
-
+    using Topshelf.HostConfigurators;
 
     public class WindowsServiceHost :
         ServiceBase,
@@ -32,11 +32,12 @@ namespace Topshelf.Runtime.Windows
         readonly HostEnvironment _environment;
         readonly ServiceHandle _serviceHandle;
         readonly HostSettings _settings;
+        readonly HostConfigurator _configurator;
         int _deadThread;
         bool _disposed;
         Exception _unhandledException;
 
-        public WindowsServiceHost(HostEnvironment environment, HostSettings settings, ServiceHandle serviceHandle)
+        public WindowsServiceHost(HostEnvironment environment, HostSettings settings, ServiceHandle serviceHandle, HostConfigurator configurator)
         {
             if (settings == null)
                 throw new ArgumentNullException("settings");
@@ -46,6 +47,7 @@ namespace Topshelf.Runtime.Windows
             _settings = settings;
             _serviceHandle = serviceHandle;
             _environment = environment;
+            _configurator = configurator;
 
             CanPauseAndContinue = settings.CanPauseAndContinue;
             CanShutdown = settings.CanShutdown;
@@ -119,6 +121,9 @@ namespace Topshelf.Runtime.Windows
                 _log.DebugFormat("[Topshelf] Current Directory: {0}", Directory.GetCurrentDirectory());
 
                 _log.DebugFormat("[Topshelf] Arguments: {0}", string.Join(",", args));
+
+                string startArgs = string.Join(" ", args);
+                _configurator.ApplyCommandLine(startArgs);
 
                 if (!_serviceHandle.Start(this))
                     throw new TopshelfException("The service did not start successfully (returned false).");


### PR DESCRIPTION
Method WindowsServiceHost.OnStart(string[] args) ignores service start arguments. This change uses the HostConfigurator.ApplyCommandLine() process these start arguments as if they were command line parameters.

This should fix the issue #146