### PR TITLE
Update NuGet.targets so that it correctly downloads stuff when behind proxy

### DIFF
--- a/src/.nuget/NuGet.targets
+++ b/src/.nuget/NuGet.targets
@@ -129,6 +129,9 @@
 
                     Log.LogMessage("Downloading latest version of NuGet.exe...");
                     WebClient webClient = new WebClient();
+                    webClient.Proxy = WebRequest.DefaultWebProxy;
+                    webClient.Proxy.Credentials = CredentialCache.DefaultCredentials;
+
                     webClient.DownloadFile("https://www.nuget.org/nuget.exe", OutputFilename);
 
                     return true;

--- a/src/.nuget/NuGet.targets
+++ b/src/.nuget/NuGet.targets
@@ -128,9 +128,12 @@
                     OutputFilename = Path.GetFullPath(OutputFilename);
 
                     Log.LogMessage("Downloading latest version of NuGet.exe...");
-                    WebClient webClient = new WebClient();
+                    WebClient webClient = new WebClient();                    
                     webClient.Proxy = WebRequest.DefaultWebProxy;
-                    webClient.Proxy.Credentials = CredentialCache.DefaultCredentials;
+                    
+                    if(webClient.Proxy != null) {
+                        webClient.Proxy.Credentials = CredentialCache.DefaultCredentials;
+                    }
 
                     webClient.DownloadFile("https://www.nuget.org/nuget.exe", OutputFilename);
 


### PR DESCRIPTION
In a corporate environment (more specifically, when working behind a proxy server), the `DownloadNuGet` task fails with 

> HTTP 407: Proxy authentication required.

This PR addresses the issue and explicitly sets `WebClient.Proxy` to whatever is the default web proxy.