### PR TITLE
Added ability to pass root level Serilog logger to Topshelf

### DIFF
--- a/src/Topshelf.Serilog/Logging/SerilogLogWriterFactory.cs
+++ b/src/Topshelf.Serilog/Logging/SerilogLogWriterFactory.cs
@@ -19,14 +19,9 @@ namespace Topshelf.Logging
     {
         readonly Func<string, ILogger> _loggerFactory;
 
-        SerilogLogWriterFactory(LoggerConfiguration loggerConfiguration)
+        SerilogLogWriterFactory(ILogger logger)
         {
-            _loggerFactory = name => loggerConfiguration.CreateLogger().ForContext("SourceContext", name);
-        }
-
-        SerilogLogWriterFactory()
-        {
-            _loggerFactory = name => Log.ForContext("SourceContext", name);
+            _loggerFactory = name => logger.ForContext("SourceContext", name);
         }
 
         public LogWriter Get(string name)
@@ -38,35 +33,24 @@ namespace Topshelf.Logging
         {
         }
 
-        public static void Use()
+        public static void Use(ILogger logger)
         {
-            HostLogger.UseLogger(new SerilogHostLoggerConfigurator());
-        }
-
-        public static void Use(LoggerConfiguration loggerConfiguration)
-        {
-            HostLogger.UseLogger(new SerilogHostLoggerConfigurator(loggerConfiguration));
+            HostLogger.UseLogger(new SerilogHostLoggerConfigurator(logger));
         }
 
         [Serializable]
         public class SerilogHostLoggerConfigurator : HostLoggerConfigurator
         {
-            readonly LoggerConfiguration _factory;
+            readonly ILogger _logger;
 
-            public SerilogHostLoggerConfigurator(LoggerConfiguration factory)
+            public SerilogHostLoggerConfigurator(ILogger logger)
             {
-                _factory = factory;
-            }
-
-            public SerilogHostLoggerConfigurator()
-            {
+                _logger = logger;
             }
 
             public LogWriterFactory CreateLogWriterFactory()
             {
-                return _factory == null 
-                    ? new SerilogLogWriterFactory() 
-                    : new SerilogLogWriterFactory(_factory);
+                return new SerilogLogWriterFactory(_logger);
             }
         }
     }

--- a/src/Topshelf.Serilog/SerilogConfigurationExtensions.cs
+++ b/src/Topshelf.Serilog/SerilogConfigurationExtensions.cs
@@ -23,7 +23,7 @@ namespace Topshelf
         /// </summary>
         public static void UseSerilog(this HostConfigurator configurator)
         {
-            SerilogLogWriterFactory.Use();
+            SerilogLogWriterFactory.Use(Log.Logger);
         }
 
         /// <summary>
@@ -31,7 +31,15 @@ namespace Topshelf
         /// </summary>
         public static void UseSerilog(this HostConfigurator configurator, LoggerConfiguration loggerConfiguration)
         {
-            SerilogLogWriterFactory.Use(loggerConfiguration);
+            SerilogLogWriterFactory.Use(loggerConfiguration.CreateLogger());
+        }
+
+        /// <summary>
+        /// Configures Topshelf to use Serilog for logging, using the given root logger <see cref="ILogger"/> to create loggers.
+        /// </summary>
+        public static void UseSerilog(this HostConfigurator configurator, ILogger rootLogger)
+        {
+            SerilogLogWriterFactory.Use(rootLogger);
         }
     }
 }


### PR DESCRIPTION
This will allow Topshelf code and app code share the same logger. Fixes #234.
Before the change, when I used FileSink Serilog would create 2 files, one for Topshelf and one for the App:

![image](https://cloud.githubusercontent.com/assets/347637/7952204/78d0637c-09f5-11e5-8dcf-9221f8934608.png)

After the change I have only one:

![image](https://cloud.githubusercontent.com/assets/347637/7952207/81a1296e-09f5-11e5-815d-d3d1e0aa84da.png)
