### PR TITLE
HostFactory sets default service name to name of entry assembly.

### DIFF
--- a/src/Topshelf/HostFactory.cs
+++ b/src/Topshelf/HostFactory.cs
@@ -13,6 +13,7 @@
 namespace Topshelf
 {
     using System;
+    using System.Reflection;
     using Configurators;
     using HostConfigurators;
     using Logging;
@@ -40,7 +41,7 @@ namespace Topshelf
                 Type declaringType = configureCallback.Method.DeclaringType;
                 if (declaringType != null)
                 {
-                    string defaultServiceName = declaringType.Namespace;
+                    string defaultServiceName = Assembly.GetEntryAssembly().GetName().Name;
                     if (!string.IsNullOrEmpty(defaultServiceName))
                         configurator.SetServiceName(defaultServiceName);
                 }


### PR DESCRIPTION
Hello! I found the unusual behavior when I installed my application as a windows service with topshelf. Service name was the same as namespace in assembly where i encapsulated working with topshelf. Architecture of my application has core library which depend on topshelf and several applications which use the library. When i try to install the applications as windows services, installation fails, because all of that applications has same name as the core library namespace. I fix this in this commit, now default windows service name is equal to entry assembly name. I will be glad to see the commit in the main repository.