### PR TITLE
Fixes issue #237: Update Nlog version to 4.1.2

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -223,7 +223,7 @@ nuspec :create_nuspec do |nuspec|
   nuspec.license_url = "http://www.apache.org/licenses/LICENSE-2.0"
   nuspec.require_license_acceptance
   nuspec.dependency "Topshelf", NUGET_VERSION
-  nuspec.dependency "NLog", "3.2.1"
+  nuspec.dependency "NLog", "4.1.2"
   nuspec.output_file = File.join(props[:artifacts], 'Topshelf.NLog.nuspec')
   add_files props[:output], 'Topshelf.NLog.{dll,pdb,xml}', nuspec
   nuspec.file(File.join(props[:src], "Topshelf.NLog\\**\\*.cs").gsub("/","\\"), "src")

--- a/src/Topshelf.NLog/Logging/NLogLogWriter.cs
+++ b/src/Topshelf.NLog/Logging/NLogLogWriter.cs
@@ -67,9 +67,9 @@ namespace Topshelf.Logging
 
         public void Log(LoggingLevel level, object obj, Exception exception)
         {
-            _log.Log(GetNLogLevel(level), obj == null
+            _log.Log(GetNLogLevel(level), exception, obj == null
                                                        ? ""
-                                                       : obj.ToString(), exception);
+                                                       : obj.ToString());
         }
 
         public void Log(LoggingLevel level, LogWriterOutputProvider messageProvider)
@@ -95,9 +95,9 @@ namespace Topshelf.Logging
 
         public void Debug(object obj, Exception exception)
         {
-            _log.Log(LogLevel.Debug, obj == null
+            _log.Log(LogLevel.Debug, exception, obj == null
                                                        ? ""
-                                                       : obj.ToString(), exception);
+                                                       : obj.ToString());
         }
 
         public void Debug(LogWriterOutputProvider messageProvider)
@@ -112,9 +112,9 @@ namespace Topshelf.Logging
 
         public void Info(object obj, Exception exception)
         {
-            _log.Log(LogLevel.Info, obj == null
+            _log.Log(LogLevel.Info, exception, obj == null
                                                       ? ""
-                                                      : obj.ToString(), exception);
+                                                      : obj.ToString());
         }
 
         public void Info(LogWriterOutputProvider messageProvider)
@@ -129,9 +129,9 @@ namespace Topshelf.Logging
 
         public void Warn(object obj, Exception exception)
         {
-            _log.Log(LogLevel.Warn, obj == null
+            _log.Log(LogLevel.Warn, exception, obj == null
                                                       ? ""
-                                                      : obj.ToString(), exception);
+                                                      : obj.ToString());
         }
 
         public void Warn(LogWriterOutputProvider messageProvider)
@@ -146,9 +146,9 @@ namespace Topshelf.Logging
 
         public void Error(object obj, Exception exception)
         {
-            _log.Log(LogLevel.Error, obj == null
+            _log.Log(LogLevel.Error, exception, obj == null
                                                        ? ""
-                                                       : obj.ToString(), exception);
+                                                       : obj.ToString());
         }
 
         public void Error(LogWriterOutputProvider messageProvider)
@@ -163,9 +163,9 @@ namespace Topshelf.Logging
 
         public void Fatal(object obj, Exception exception)
         {
-            _log.Log(LogLevel.Fatal, obj == null
+            _log.Log(LogLevel.Fatal, exception, obj == null
                                                        ? ""
-                                                       : obj.ToString(), exception);
+                                                       : obj.ToString());
         }
 
         public void Fatal(LogWriterOutputProvider messageProvider)

--- a/src/Topshelf.NLog/Topshelf.NLog.csproj
+++ b/src/Topshelf.NLog/Topshelf.NLog.csproj
@@ -38,10 +38,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog" Condition="'$(TargetFrameworkVersion)' == 'v3.5'">
-      <HintPath>..\packages\NLog.3.2.1\lib\net35\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.1.2\lib\net35\NLog.dll</HintPath>
     </Reference>
     <Reference Include="NLog" Condition="'$(TargetFrameworkVersion)' != 'v3.5'">
-      <HintPath>..\packages\NLog.3.2.1\lib\net40\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.1.2\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Topshelf.NLog/packages.config
+++ b/src/Topshelf.NLog/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="3.2.1" targetFramework="net40" />
+  <package id="NLog" version="4.1.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Migrate all method matching the new Nlog v4 API for logging exceptions.