### PR TITLE
Added ability to specify Elmah log levels

### DIFF
--- a/src/Topshelf.Elmah/ElmahConfigurationExtensions.cs
+++ b/src/Topshelf.Elmah/ElmahConfigurationExtensions.cs
@@ -28,5 +28,15 @@ namespace Topshelf
         {
             ElmahLogWriterFactory.Use();
         }
+
+        /// <summary>
+        ///   Specify that you want to use the Elmah logging engine.
+        /// </summary>
+        /// <param name="configurator"> </param>
+        /// <param name="logLevels">The desired level of elmah logging</param>
+        public static void UseElmah(this HostConfigurator configurator, ElmahLogLevels logLevels)
+        {
+            ElmahLogWriterFactory.Use(logLevels);
+        }
     }
 }

--- a/src/Topshelf.Elmah/Logging/ElmahLogWriter.cs
+++ b/src/Topshelf.Elmah/Logging/ElmahLogWriter.cs
@@ -82,7 +82,8 @@ namespace Topshelf.Logging
             error.HostName = Environment.MachineName;
             error.Detail = exception == null ? message : exception.StackTrace;
 
-            _log.Log(error);
+            if(IsLogLevelEnabled(logLevel))
+                _log.Log(error);
         }
 
         private string GetLogLevel(ElmahLogLevelsEnum logLevel)
@@ -244,7 +245,23 @@ namespace Topshelf.Logging
         {
             WriteToElmah(ElmahLogLevelsEnum.Fatal, format, args);
         }
-
+        private bool IsLogLevelEnabled(ElmahLogLevelsEnum logLevel)
+        {
+            switch (logLevel)
+            {
+                case ElmahLogLevelsEnum.Debug:
+                    return IsDebugEnabled;
+                case ElmahLogLevelsEnum.Info:
+                    return IsInfoEnabled;
+                case ElmahLogLevelsEnum.Warn:
+                    return IsWarnEnabled;
+                case ElmahLogLevelsEnum.Error:
+                    return IsErrorEnabled;
+                case ElmahLogLevelsEnum.Fatal:
+                    return IsFatalEnabled;
+            }
+            return true;
+        }
         public bool IsDebugEnabled
         {
             get { return _logLevels.IsDebugEnabled; }

--- a/src/Topshelf.Elmah/Logging/ElmahLogWriterFactory.cs
+++ b/src/Topshelf.Elmah/Logging/ElmahLogWriterFactory.cs
@@ -18,6 +18,12 @@ namespace Topshelf.Logging
     public class ElmahLogWriterFactory :
         LogWriterFactory
     {
+        private readonly ElmahLogLevels _logLevels;
+        private ElmahLogWriterFactory(ElmahLogLevels logLevels)
+        {
+            _logLevels = logLevels;
+        }
+
         public LogWriter Get(string name)
         {
             return new ElmahLogWriter();
@@ -28,9 +34,9 @@ namespace Topshelf.Logging
 
         }
 
-        public static void Use()
+        public static void Use(ElmahLogLevels logLevels = null)
         {
-            HostLogger.UseLogger(new ElmahHostLoggerConfigurator());
+            HostLogger.UseLogger(new ElmahHostLoggerConfigurator(logLevels));
         }
 
 
@@ -38,9 +44,15 @@ namespace Topshelf.Logging
         public class ElmahHostLoggerConfigurator :
             HostLoggerConfigurator
         {
+            private readonly ElmahLogLevels _logLevels;
+            public ElmahHostLoggerConfigurator(ElmahLogLevels logLevels)
+            {
+                _logLevels = logLevels;
+            }
+
             public LogWriterFactory CreateLogWriterFactory()
             {
-                return new ElmahLogWriterFactory();
+                return new ElmahLogWriterFactory(_logLevels);
             }
         }
     }

--- a/src/Topshelf.Elmah/Logging/ElmahLogWriterFactory.cs
+++ b/src/Topshelf.Elmah/Logging/ElmahLogWriterFactory.cs
@@ -26,7 +26,7 @@ namespace Topshelf.Logging
 
         public LogWriter Get(string name)
         {
-            return new ElmahLogWriter();
+            return new ElmahLogWriter(_logLevels);
         }
 
         public void Shutdown()


### PR DESCRIPTION
I added the ability to pass LogLevels into the constructor so that you can control which levels are output in your application.

The use case is that in production only error and fatal messages should be logged to Elmah. In other environments all messages should be turned on.

Moving access to the ElmahLogLevel object out allows applications to control which messages get logged.