### PR TITLE
Added example for parameters name with spaces

### DIFF
--- a/doc/source/overview/commandline.rst
+++ b/doc/source/overview/commandline.rst
@@ -37,9 +37,13 @@ The help text from the command line is shown below for easy reference.
       -servicename      The name that the service should use when
                         installing
       -description      The service description the service should use when
-                        installing
+                        installing. 
+                        Eg: -description: MyService
+                        Eg: -description "My Service"
       -displayname      The display name the the service should use when
                         installing
+                        Eg: -displayname: MyService
+                        Eg: -displayname "My Service"
 
     **start**             Starts the service if it is not already running
 


### PR DESCRIPTION
The documentation does not explains that for some parameters, if the value constains spaces TopShelf does not recognizes the values and takes it as anunknow verb