### PR TITLE
Use case-insensitive comparison for service names

### DIFF
--- a/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
@@ -305,7 +305,7 @@ namespace Topshelf.Runtime.Windows
             try
             {
                 result = ServiceController.GetServices()
-                                    .Any(service => string.CompareOrdinal(service.ServiceName, serviceName) == 0);
+                                    .Any(service => string.Equals(service.ServiceName, serviceName, StringComparison.OrdinalIgnoreCase)));
             }
             catch (InvalidOperationException)
             {


### PR DESCRIPTION
Windows treats service names in a case-insensitive fashion. With a case-sensitive comparison problems can arise if you:
1. Build and install Myservice.
2. Create a new release with nicer casing: MyService.
3. xcopy deploy over the old installation and try to start it.