### PR TITLE
Enhanced command line documentation to include examples

### DIFF
--- a/doc/source/overview/commandline.rst
+++ b/doc/source/overview/commandline.rst
@@ -58,3 +58,15 @@ The help text from the command line is shown below for easy reference.
       -instance         An instance name if registering the service
                         multiple times
       --sudo            Prompts for UAC if running on Vista/W7/2008
+
+
+Examples
+'''''''''
+    
+    ** Basic Service Installation**
+    MyService.exe install -username:DOMAIN\ServiceAccount -password:itsASecret -servicename:AwesomeService --autostart
+    
+    ** Service Installation with Quoted Arguments
+    MyService.exe install -username "DOMAIN\Service Account" -password:"Its A Secret" -servicename "Awesome Service" --autostart
+    
+    


### PR DESCRIPTION
It took me a long time to discover that  it's acceptable to uses spaces to separate argument names from values instead of the colon. This necessary with quoted argument values.