### PR TITLE
Power Events for Topshelf

### DIFF
--- a/src/Topshelf/Configuration/Builders/ControlServiceBuilder.cs
+++ b/src/Topshelf/Configuration/Builders/ControlServiceBuilder.cs
@@ -111,6 +111,17 @@ namespace Topshelf.Builders
                 }
             }
 
+            public bool PowerEvent(HostControl hostControl, PowerEventArguments arguments)
+            {
+                var powerChange = _service as ServicePowerEvent;
+                if (powerChange != null)
+                {
+                    return powerChange.PowerEvent(hostControl, arguments);
+                }
+
+                return false;
+            }
+
             public void CustomCommand(HostControl hostControl, int command)
             {
                 var customCommand = _service as ServiceCustomCommand;

--- a/src/Topshelf/Configuration/Builders/ControlServiceBuilder.cs
+++ b/src/Topshelf/Configuration/Builders/ControlServiceBuilder.cs
@@ -113,10 +113,10 @@ namespace Topshelf.Builders
 
             public bool PowerEvent(HostControl hostControl, PowerEventArguments arguments)
             {
-                var powerChange = _service as ServicePowerEvent;
-                if (powerChange != null)
+                var powerEvent = _service as ServicePowerEvent;
+                if (powerEvent != null)
                 {
-                    return powerChange.PowerEvent(hostControl, arguments);
+                    return powerEvent.PowerEvent(hostControl, arguments);
                 }
 
                 return false;

--- a/src/Topshelf/Configuration/ServiceConfiguratorExtensions.cs
+++ b/src/Topshelf/Configuration/ServiceConfiguratorExtensions.cs
@@ -134,5 +134,17 @@ namespace Topshelf
 
            return configurator;
        }
-  }
+
+        public static ServiceConfigurator<T> WhenPowerEvent<T>(this ServiceConfigurator<T> configurator, 
+            Func<T, PowerEventArguments, bool> callback)
+            where T : class
+        {
+            if (configurator == null)
+                throw new ArgumentNullException("configurator");
+
+            configurator.WhenPowerEvent((service, control, arguments) => callback(service, arguments));
+
+            return configurator;
+        }
+    }
 }

--- a/src/Topshelf/Configuration/ServiceConfigurators/DelegateServiceConfigurator.cs
+++ b/src/Topshelf/Configuration/ServiceConfigurators/DelegateServiceConfigurator.cs
@@ -32,7 +32,9 @@ namespace Topshelf.ServiceConfigurators
 
         bool _pauseConfigured;
         bool _sessionChangeConfigured;
+        bool _powerEventConfigured;
         Action<T, HostControl, SessionChangedArguments> _sessionChanged;
+        Func<T, HostControl, PowerEventArguments, bool> _powerEvent;
         Action<T, HostControl> _shutdown;
         bool _shutdownConfigured;
         Func<T, HostControl, bool> _start;
@@ -57,6 +59,8 @@ namespace Topshelf.ServiceConfigurators
                 yield return this.Failure("Shutdown", "must not be null if shutdown is allowed");
             if (_sessionChangeConfigured && _sessionChanged == null)
                 yield return this.Failure("SessionChange", "must not be null if session change is allowed");
+            if (_powerEventConfigured && _powerEvent == null)
+                yield return this.Failure("PowerEvent", "must not be null if power event reaction is allowed");
             if (_customCommandReceivedConfigured && _customCommandReceived == null)
                 yield return this.Failure("CustomCommand", "must not be null if custom command is allowed");
         }
@@ -100,6 +104,12 @@ namespace Topshelf.ServiceConfigurators
             _sessionChanged = sessionChanged;
         }
 
+        public void WhenPowerEvent(Func<T, HostControl, PowerEventArguments, bool> powerEvent)
+        {
+            _powerEventConfigured = true;
+            _powerEvent = powerEvent;
+        }
+
         public void WhenCustomCommandReceived(Action<T, HostControl, int> customCommandReceived)
         {
             _customCommandReceivedConfigured = true;
@@ -109,7 +119,7 @@ namespace Topshelf.ServiceConfigurators
         public ServiceBuilder Build()
         {
             var serviceBuilder = new DelegateServiceBuilder<T>(_factory, _start, _stop, _pause, _continue, _shutdown,
-                _sessionChanged, _customCommandReceived, ServiceEvents);
+                _sessionChanged, _powerEvent, _customCommandReceived, ServiceEvents);
             return serviceBuilder;
         }
     }

--- a/src/Topshelf/Configuration/ServiceConfigurators/ServiceConfigurator.cs
+++ b/src/Topshelf/Configuration/ServiceConfigurators/ServiceConfigurator.cs
@@ -49,6 +49,7 @@ namespace Topshelf.ServiceConfigurators
         void WhenContinued(Func<T, HostControl, bool> @continue);
         void WhenShutdown(Action<T, HostControl> shutdown);
         void WhenSessionChanged(Action<T, HostControl, SessionChangedArguments> sessionChanged);
+        void WhenPowerEvent(Func<T, HostControl, PowerEventArguments, bool> powerEvent);
         void WhenCustomCommandReceived(Action<T, HostControl, int> customCommandReceived);
     }
 }

--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -268,9 +268,9 @@ namespace Topshelf.Hosts
             PowerEventArguments
         {
             readonly PowerEventCode _eventCode;
-            public ConsolePowerEventArguments(PowerModes powerModes)
+            public ConsolePowerEventArguments(PowerModes powerMode)
             {
-                switch (powerModes)
+                switch (powerMode)
                 {
                     case PowerModes.Resume:
                         _eventCode = PowerEventCode.ResumeAutomatic; 
@@ -282,7 +282,7 @@ namespace Topshelf.Hosts
                         _eventCode = PowerEventCode.Suspend;
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(powerModes), powerModes, null);
+                        throw new ArgumentOutOfRangeException(nameof(powerMode), powerMode, null);
                 }
             }
 

--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -267,9 +267,28 @@ namespace Topshelf.Hosts
         class ConsolePowerEventArguments :
             PowerEventArguments
         {
+            readonly PowerEventCode _eventCode;
             public ConsolePowerEventArguments(PowerModes powerModes)
             {
-                // TODO map 
+                switch (powerModes)
+                {
+                    case PowerModes.Resume:
+                        _eventCode = PowerEventCode.ResumeAutomatic; 
+                        break;
+                    case PowerModes.StatusChange:
+                        _eventCode = PowerEventCode.PowerStatusChange;
+                        break;
+                    case PowerModes.Suspend:
+                        _eventCode = PowerEventCode.Suspend;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(powerModes), powerModes, null);
+                }
+            }
+
+            public PowerEventCode EventCode
+            {
+                get { return _eventCode; }
             }
         }
     }

--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -53,6 +53,11 @@ namespace Topshelf.Hosts
             {
                 SystemEvents.SessionSwitch += OnSessionChanged;
             }
+
+            if (settings.CanHandlePowerEvent)
+            {
+                SystemEvents.PowerModeChanged += OnPowerModeChanged;
+            }
         }
 
         void OnSessionChanged(object sender, SessionSwitchEventArgs e)
@@ -60,6 +65,13 @@ namespace Topshelf.Hosts
             var arguments = new ConsoleSessionChangedArguments(e.Reason);
 
             _serviceHandle.SessionChanged(this, arguments);
+        }
+
+        void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
+        {
+            var arguments = new ConsolePowerEventArguments(e.Mode);
+
+            _serviceHandle.PowerEvent(this, arguments);
         }
 
 
@@ -249,6 +261,15 @@ namespace Topshelf.Hosts
             public int SessionId
             {
                 get { return _sessionId; }
+            }
+        }
+
+        class ConsolePowerEventArguments :
+            PowerEventArguments
+        {
+            public ConsolePowerEventArguments(PowerModes powerModes)
+            {
+                // TODO map 
             }
         }
     }

--- a/src/Topshelf/Hosts/InstallHost.cs
+++ b/src/Topshelf/Hosts/InstallHost.cs
@@ -179,6 +179,14 @@ namespace Topshelf.Hosts
                 get { return _settings.CanSessionChanged; }
             }
 
+            /// <summary>
+            /// True if the service handles power change events
+            /// </summary>
+            public bool CanHandlePowerEvent
+            {
+                get { return _settings.CanHandlePowerEvent; }
+            }
+
             public Credentials Credentials
             {
                 get { return _credentials; }

--- a/src/Topshelf/PowerEventArguments.cs
+++ b/src/Topshelf/PowerEventArguments.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Topshelf
+{
+    public interface PowerEventArguments
+    {
+        // TODO
+    }
+}

--- a/src/Topshelf/PowerEventCode.cs
+++ b/src/Topshelf/PowerEventCode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
 //  
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
 // this file except in compliance with the License. You may obtain a copy of the 
@@ -12,8 +12,16 @@
 // specific language governing permissions and limitations under the License.
 namespace Topshelf
 {
-    public interface PowerEventArguments
+    public enum PowerEventCode
     {
-        PowerEventCode EventCode { get; }
+        QuerySuspend = 0,
+        QuerySuspendFailed = 2,
+        Suspend = 4,
+        ResumeCritical = 6,
+        ResumeSuspend = 7,
+        BatteryLow = 9,
+        PowerStatusChange = 10,
+        OemEvent = 11,
+        ResumeAutomatic = 18
     }
 }

--- a/src/Topshelf/PowerEventCode.cs
+++ b/src/Topshelf/PowerEventCode.cs
@@ -12,16 +12,51 @@
 // specific language governing permissions and limitations under the License.
 namespace Topshelf
 {
+    using Hosts;
+
     public enum PowerEventCode
     {
+        /// <summary>
+        /// The system has requested permission to suspend the computer. An application that grants permission should carry out preparations for the suspension before returning.
+        /// <remarks>Not supported by <see cref="ConsoleRunHost"/></remarks>
+        /// </summary>
         QuerySuspend = 0,
+        /// <summary>
+        /// The system was denied permission to suspend the computer. This status is broadcast if any application or driver denied a previous <see cref="QuerySuspend"/> status.
+        /// <remarks>Not supported by <see cref="ConsoleRunHost"/></remarks>
+        /// </summary>
         QuerySuspendFailed = 2,
+        /// <summary>
+        /// The computer is about to enter a suspended state. This event is typically broadcast when all applications and installable drivers have returned true to a previous QuerySuspend state.
+        /// </summary>
         Suspend = 4,
+        /// <summary>
+        /// The system has resumed operation after a critical suspension caused by a failing battery.
+        /// <remarks>Not supported by <see cref="ConsoleRunHost"/></remarks>
+        /// </summary>
         ResumeCritical = 6,
+        /// <summary>
+        /// The system has resumed operation after being suspended.
+        /// <remarks>Not supported by <see cref="ConsoleRunHost"/></remarks>
+        /// </summary>
         ResumeSuspend = 7,
+        /// <summary>
+        /// Battery power is low.
+        /// <remarks>Not supported by <see cref="ConsoleRunHost"/></remarks>
+        /// </summary>
         BatteryLow = 9,
+        /// <summary>
+        /// A change in the power status of the computer is detected, such as a switch from battery power to A/C. The system also broadcasts this event when remaining battery power slips below the threshold specified by the user or if the battery power changes by a specified percentage.
+        /// </summary>
         PowerStatusChange = 10,
+        /// <summary>
+        /// An Advanced Power Management (APM) BIOS signaled an APM OEM event.
+        /// <remarks>Not supported by <see cref="ConsoleRunHost"/></remarks>
+        /// </summary>
         OemEvent = 11,
+        /// <summary>
+        /// The computer has woken up automatically to handle an event.
+        /// </summary>
         ResumeAutomatic = 18
     }
 }

--- a/src/Topshelf/Runtime/HostSettings.cs
+++ b/src/Topshelf/Runtime/HostSettings.cs
@@ -61,6 +61,11 @@ namespace Topshelf.Runtime
         bool CanSessionChanged { get; }
 
         /// <summary>
+        /// True if the service handles power change events
+        /// </summary>
+        bool CanHandlePowerEvent { get; }
+
+        /// <summary>
         /// The amount of time to wait for the service to start before timing out. Default is 10 seconds.
         /// </summary>
         TimeSpan StartTimeOut { get; }

--- a/src/Topshelf/Runtime/ServiceHandle.cs
+++ b/src/Topshelf/Runtime/ServiceHandle.cs
@@ -63,6 +63,13 @@ namespace Topshelf.Runtime
         void SessionChanged(HostControl hostControl, SessionChangedArguments arguments);
 
         /// <summary>
+        /// Handle the power change event
+        /// </summary>
+        /// <param name="hostControl"></param>
+        /// <param name="arguments"></param>
+        bool PowerEvent(HostControl hostControl, PowerEventArguments arguments);
+
+        /// <summary>
         /// Handle the custom command
         /// </summary>
         /// <param name="hostControl"></param>

--- a/src/Topshelf/Runtime/Windows/WindowsHostSettings.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostSettings.cs
@@ -102,6 +102,8 @@ namespace Topshelf.Runtime.Windows
 
         public bool CanSessionChanged { get; set; }
         
+        public bool CanHandlePowerEvent { get; set; }
+
         public TimeSpan StartTimeOut { get; set; }
         
         public TimeSpan StopTimeOut { get; set; }

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -238,13 +238,13 @@ namespace Topshelf.Runtime.Windows
 
                 _serviceHandle.SessionChanged(this, arguments);
 
-                _log.Info("[Topshelf] Stopped");
+                _log.Info("[Topshelf] Service session changed handled");
             }
             catch (Exception ex)
             {
                 _settings.ExceptionCallback?.Invoke(ex);
 
-                _log.Fatal("The service did not shut down gracefully", ex);
+                _log.Fatal("The did not handle Service session change correctly", ex);
                 ExitCode = (int)TopshelfExitCode.StopServiceFailed;
                 throw;
             }
@@ -254,19 +254,21 @@ namespace Topshelf.Runtime.Windows
         {
             try
             {
-                _log.Info("[Topshelf] Power event changed");
+                _log.Info("[Topshelf] Power event raised");
 
                 var arguments = new WindowsPowerEventArguments(powerStatus);
 
-                var result = this._serviceHandle.PowerEvent(this, arguments);
+                var result = _serviceHandle.PowerEvent(this, arguments);
 
-                _log.Info("[Topshelf] Stopped");
+                _log.Info("[Topshelf] Power event handled");
 
                 return result;
             }
             catch (Exception ex)
             {
-                _log.Fatal("The service did not shut down gracefully", ex);
+                _settings.ExceptionCallback?.Invoke(ex);
+
+                _log.Fatal("The service did handle the Power event correctly", ex);
                 ExitCode = (int)TopshelfExitCode.StopServiceFailed;
                 throw;
             }

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -49,6 +49,7 @@ namespace Topshelf.Runtime.Windows
 
             CanPauseAndContinue = settings.CanPauseAndContinue;
             CanShutdown = settings.CanShutdown;
+            CanHandlePowerEvent = settings.CanHandlePowerEvent;
             CanHandleSessionChangeEvent = settings.CanSessionChanged;
             ServiceName = _settings.ServiceName;
         }
@@ -249,6 +250,29 @@ namespace Topshelf.Runtime.Windows
             }
         }
 
+        protected override bool OnPowerEvent(PowerBroadcastStatus powerStatus)
+        {
+            try
+            {
+                _log.Info("[Topshelf] Power event changed");
+
+                var arguments = new WindowsPowerEventArguments(powerStatus);
+
+                var result = this._serviceHandle.PowerEvent(this, arguments);
+
+                _log.Info("[Topshelf] Stopped");
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _log.Fatal("The service did not shut down gracefully", ex);
+                ExitCode = (int)TopshelfExitCode.StopServiceFailed;
+                throw;
+            }
+
+        }
+
         protected override void OnCustomCommand(int command)
         {
             try
@@ -333,6 +357,15 @@ namespace Topshelf.Runtime.Windows
             public int SessionId
             {
                 get { return _sessionId; }
+            }
+        }
+
+        class WindowsPowerEventArguments :
+            PowerEventArguments
+        {
+            public WindowsPowerEventArguments(PowerBroadcastStatus powerStatus)
+            {
+                // TODO
             }
         }
     }

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -363,9 +363,17 @@ namespace Topshelf.Runtime.Windows
         class WindowsPowerEventArguments :
             PowerEventArguments
         {
+            readonly PowerEventCode _eventCode;
+
             public WindowsPowerEventArguments(PowerBroadcastStatus powerStatus)
             {
-                // TODO
+                _eventCode = (PowerEventCode) Enum.ToObject(typeof(PowerEventCode), (int)powerStatus);
+            }
+
+
+            public PowerEventCode EventCode
+            {
+                get { return _eventCode; }
             }
         }
     }

--- a/src/Topshelf/ServicePowerEvent.cs
+++ b/src/Topshelf/ServicePowerEvent.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Topshelf
+{
+    /// <summary>
+    /// Implemented by services that support power change events
+    /// </summary>
+    public interface ServicePowerEvent
+    {
+        bool PowerEvent(HostControl hostControl, PowerEventArguments changedArguments);
+    }
+}

--- a/src/Topshelf/Topshelf.csproj
+++ b/src/Topshelf/Topshelf.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Logging\TraceLogWriterFactory.cs" />
     <Compile Include="Logging\TypeExtensions.cs" />
     <Compile Include="Logging\TypeNameFormatter.cs" />
+    <Compile Include="PowerEventCode.cs" />
     <Compile Include="Runtime\EventCallbackList.cs" />
     <Compile Include="Runtime\HostEnvironment.cs" />
     <Compile Include="Runtime\HostStartMode.cs" />

--- a/src/Topshelf/Topshelf.csproj
+++ b/src/Topshelf/Topshelf.csproj
@@ -229,9 +229,11 @@
     <Compile Include="Runtime\Windows\WindowsUserAccessControl.cs" />
     <Compile Include="ServiceControl.cs" />
     <Compile Include="ServiceCustomCommand.cs" />
+    <Compile Include="ServicePowerEvent.cs" />
     <Compile Include="ServiceSessionChange.cs" />
     <Compile Include="ServiceShutdown.cs" />
     <Compile Include="ServiceSuspend.cs" />
+    <Compile Include="PowerEventArguments.cs" />
     <Compile Include="SessionChangedArguments.cs" />
     <Compile Include="SessionChangeReasonCode.cs" />
     <Compile Include="TopshelfExitCode.cs" />


### PR DESCRIPTION
* [x] Initial code to support the events
* [x] Map the types from the CLR/API to something we understand, this is hard, since the [PowerModes](https://msdn.microsoft.com/en-us/library/microsoft.win32.powermodes(v=vs.110).aspx) and [PowerBroadcastStatus](https://msdn.microsoft.com/en-us/library/system.serviceprocess.powerbroadcaststatus(v=vs.110).aspx) are not interchangeable. 

When done, this should resolve https://github.com/Topshelf/Topshelf/issues/170