### PR TITLE
Adding a callback for clients to act upon exceptions (including unhandled)

### DIFF
--- a/doc/source/configuration/config_api.rst
+++ b/doc/source/configuration/config_api.rst
@@ -363,6 +363,22 @@ Specifies that the service supports the shutdown service command, allowing the s
     });
 
 
+OnException
+--------------
+
+Provides a callback for exceptions that are thrown while the service is running. This callback is not a handler, and will not affect the default exception handling that Topshelf already provides. It is intended to provide visibility into thrown exceptions for triggering external actions, logging, etc.
+
+.. sourcecode:: csharp
+
+    HostFactory.New(x =>
+    {
+        x.OnException(ex =>
+        {
+            // Do something with the exception
+        });
+    });
+
+
 Service Recovery
 ================
 

--- a/src/SampleTopshelfService/Program.cs
+++ b/src/SampleTopshelfService/Program.cs
@@ -52,9 +52,9 @@ namespace SampleTopshelfService
                     x.AddCommandLineSwitch("throwonstop", v => throwOnStop = v);
                     x.AddCommandLineSwitch("throwunhandled", v => throwUnhandled = v);
 
-                    x.AddExceptionHandler(ex =>
+                    x.OnException((exception) =>
                     {
-                        Console.WriteLine("Exception thrown - " + ex.Message);
+                        Console.WriteLine("Exception thrown - " + exception.Message);
                     });
                 });
         }

--- a/src/Topshelf.Tests/ExceptionHandler_Specs.cs
+++ b/src/Topshelf.Tests/ExceptionHandler_Specs.cs
@@ -1,0 +1,166 @@
+﻿// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Topshelf.Tests
+{
+    using System;
+    using NUnit.Framework;
+
+
+    [TestFixture]
+    public class Exception_callback
+    {
+        private static readonly string StartExceptionMessage = "Throw on Start Requested";
+        private static readonly string StopExceptionMessage = "Throw on Stop Requested";
+
+        [Test]
+        public void Should_be_called_when_exception_thrown_in_Start_method()
+        {
+            var sawExceptionInStart = false;
+            var sawExceptionInStop = false;
+
+            var exitCode = HostFactory.Run(x =>
+                {
+                    x.UseTestHost();
+
+                    x.Service(settings => new ExceptionThrowingService(true, false));
+
+                    x.OnException(ex =>
+                    {
+                        if (ex.Message == StartExceptionMessage)
+                        {
+                            sawExceptionInStart = true;
+                        }
+
+                        if (ex.Message == StopExceptionMessage)
+                        {
+                            sawExceptionInStop = true;
+                        }
+                    });
+                });
+
+            Assert.IsTrue(sawExceptionInStart);
+            Assert.IsFalse(sawExceptionInStop);
+            Assert.AreEqual(TopshelfExitCode.StartServiceFailed, exitCode);
+        }
+
+        [Test]
+        public void Should_be_called_when_exception_thrown_in_Stop_method()
+        {
+            var sawExceptionInStart = false;
+            var sawExceptionInStop = false;
+
+            var exitCode = HostFactory.Run(x =>
+            {
+                x.UseTestHost();
+
+                x.Service(settings => new ExceptionThrowingService(false, true));
+
+                x.OnException(ex =>
+                {
+                    if (ex.Message == StartExceptionMessage)
+                    {
+                        sawExceptionInStart = true;
+                    }
+
+                    if (ex.Message == StopExceptionMessage)
+                    {
+                        sawExceptionInStop = true;
+                    }
+                });
+            });
+
+            Assert.IsFalse(sawExceptionInStart);
+            Assert.IsTrue(sawExceptionInStop);
+            Assert.AreEqual(TopshelfExitCode.StopServiceFailed, exitCode);
+        }
+
+        [Test]
+        public void Should_not_be_called_when_no_exceptions_thrown()
+        {
+            var sawException = false;
+
+            var exitCode = HostFactory.Run(x =>
+            {
+                x.UseTestHost();
+
+                x.Service(settings => new ExceptionThrowingService(false, false));
+
+                x.OnException(ex =>
+                {
+                    sawException = true;
+                });
+            });
+
+            Assert.IsFalse(sawException);
+            Assert.AreEqual(TopshelfExitCode.Ok, exitCode);
+        }
+
+        [Test]
+        public void Should_not_prevent_default_action_when_not_set()
+        {
+            var exitCode = HostFactory.Run(x =>
+            {
+                x.UseTestHost();
+
+                x.Service(settings => new ExceptionThrowingService(true, false));
+            });
+
+            Assert.AreEqual(TopshelfExitCode.StartServiceFailed, exitCode);
+
+            exitCode = HostFactory.Run(x =>
+            {
+                x.UseTestHost();
+
+                x.Service(settings => new ExceptionThrowingService(false, true));
+            });
+
+            Assert.AreEqual(TopshelfExitCode.StopServiceFailed, exitCode);
+
+        }
+
+        /// <summary>
+        /// A simple service that can be configured to throw exceptions while starting or stopping.
+        /// </summary>
+        class ExceptionThrowingService : ServiceControl
+        {
+            readonly bool _throwOnStart;
+            readonly bool _throwOnStop;
+
+            public ExceptionThrowingService(bool throwOnStart, bool throwOnStop)
+            {
+                _throwOnStart = throwOnStart;
+                _throwOnStop = throwOnStop;
+            }
+
+            public bool Start(HostControl hostControl)
+            {
+                if (_throwOnStart)
+                {
+                    throw new InvalidOperationException(StartExceptionMessage);
+                }
+
+                return true;
+            }
+
+            public bool Stop(HostControl hostControl)
+            {
+                if (_throwOnStop)
+                {
+                    throw new InvalidOperationException(StopExceptionMessage);
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Topshelf.Tests/Topshelf.Tests.csproj
+++ b/src/Topshelf.Tests/Topshelf.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="..\SolutionVersion.cs">
       <Link>SolutionVersion.cs</Link>
     </Compile>
+    <Compile Include="ExceptionHandler_Specs.cs" />
     <Compile Include="BeforeStart_Specs.cs" />
     <Compile Include="CommandLine_Specs.cs" />
     <Compile Include="Help_Specs.cs" />

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
@@ -122,6 +122,6 @@ namespace Topshelf.HostConfigurators
         /// by Topshelf while a service is starting, running or stopping.
         /// </summary>
         /// <param name="callback"></param>
-        void AddExceptionHandler(Action<Exception> callback);
+        void OnException(Action<Exception> callback);
     }
 }

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
@@ -118,10 +118,12 @@ namespace Topshelf.HostConfigurators
         void AddCommandLineDefinition(string name, Action<string> callback);
 
         /// <summary>
-        /// Adds custom exception handler that will be called for any exception caught
-        /// by Topshelf while a service is starting, running or stopping.
+        /// Specifies a callback to be run when Topshelf encounters an exception while starting, running
+        /// or stopping. This callback does not replace Topshelf's default handling of any exceptions, and 
+        /// is intended to allow for local cleanup, logging, etc. This is not required, and is only invoked
+        /// if a callback is provided.
         /// </summary>
-        /// <param name="callback"></param>
+        /// <param name="callback">The action to run when an exception occurs.</param>
         void OnException(Action<Exception> callback);
     }
 }

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -184,7 +184,7 @@ namespace Topshelf.HostConfigurators
 
         public void OnException(Action<Exception> callback)
         {
-            _settings.ExceptionHandler = callback;
+            _settings.ExceptionCallback = callback;
         }
 
         public Host CreateHost()

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -182,7 +182,7 @@ namespace Topshelf.HostConfigurators
             _commandLineOptionConfigurators.Add(configurator);
         }
 
-        public void AddExceptionHandler(Action<Exception> callback)
+        public void OnException(Action<Exception> callback)
         {
             _settings.ExceptionHandler = callback;
         }

--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -102,8 +102,6 @@ namespace Topshelf.Hosts
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Error("An exception occurred", ex);
@@ -148,8 +146,6 @@ namespace Topshelf.Hosts
 
         void CatchUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            // Call the custom exception handler if it is not null
-            //
             _settings.ExceptionCallback?.Invoke((Exception)e.ExceptionObject);
 
             _log.Fatal("The service threw an unhandled exception", (Exception)e.ExceptionObject);
@@ -193,8 +189,6 @@ namespace Topshelf.Hosts
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Error("The service did not shut down gracefully", ex);

--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -104,7 +104,7 @@ namespace Topshelf.Hosts
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Error("An exception occurred", ex);
 
@@ -150,7 +150,7 @@ namespace Topshelf.Hosts
         {
             // Call the custom exception handler if it is not null
             //
-            _settings.ExceptionHandler?.Invoke((Exception)e.ExceptionObject);
+            _settings.ExceptionCallback?.Invoke((Exception)e.ExceptionObject);
 
             _log.Fatal("The service threw an unhandled exception", (Exception)e.ExceptionObject);
 
@@ -195,7 +195,7 @@ namespace Topshelf.Hosts
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Error("The service did not shut down gracefully", ex);
             }

--- a/src/Topshelf/Hosts/InstallHost.cs
+++ b/src/Topshelf/Hosts/InstallHost.cs
@@ -205,9 +205,9 @@ namespace Topshelf.Hosts
               get { return _settings.StopTimeOut; }
             }
 
-            public Action<Exception> ExceptionHandler
+            public Action<Exception> ExceptionCallback
             {
-                get { return _settings.ExceptionHandler; }
+                get { return _settings.ExceptionCallback; }
             }
         }
     }

--- a/src/Topshelf/Hosts/TestHost.cs
+++ b/src/Topshelf/Hosts/TestHost.cs
@@ -61,8 +61,6 @@ namespace Topshelf.Hosts
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Error("The service threw an exception during testing.", ex);

--- a/src/Topshelf/Hosts/TestHost.cs
+++ b/src/Topshelf/Hosts/TestHost.cs
@@ -61,6 +61,10 @@ namespace Topshelf.Hosts
             }
             catch (Exception ex)
             {
+                // Call the custom exception handler if it is not null
+                //
+                _settings.ExceptionCallback?.Invoke(ex);
+
                 _log.Error("The service threw an exception during testing.", ex);
             }
             finally

--- a/src/Topshelf/Runtime/HostSettings.cs
+++ b/src/Topshelf/Runtime/HostSettings.cs
@@ -71,8 +71,9 @@ namespace Topshelf.Runtime
         TimeSpan StopTimeOut { get; }
 
         /// <summary>
-        /// A callback to provide additional exception handling beyond what is already provided
+        /// A callback to provide visibility into exceptions while Topshelf is performing its
+        /// own handling.
         /// </summary>
-        Action<Exception> ExceptionHandler { get; }
+        Action<Exception> ExceptionCallback { get; }
     }
 }

--- a/src/Topshelf/Runtime/Windows/WindowsHostSettings.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostSettings.cs
@@ -106,6 +106,6 @@ namespace Topshelf.Runtime.Windows
         
         public TimeSpan StopTimeOut { get; set; }
 
-        public Action<Exception> ExceptionHandler { get; set; }
+        public Action<Exception> ExceptionCallback { get; set; }
     }
 }

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -130,8 +130,6 @@ namespace Topshelf.Runtime.Windows
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not start successfully", ex);
@@ -154,8 +152,6 @@ namespace Topshelf.Runtime.Windows
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not shut down gracefully", ex);
@@ -184,8 +180,6 @@ namespace Topshelf.Runtime.Windows
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not pause gracefully", ex);
@@ -206,8 +200,6 @@ namespace Topshelf.Runtime.Windows
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not resume successfully", ex);
@@ -227,8 +219,6 @@ namespace Topshelf.Runtime.Windows
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not shut down gracefully", ex);
@@ -251,8 +241,6 @@ namespace Topshelf.Runtime.Windows
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not shut down gracefully", ex);
@@ -273,8 +261,6 @@ namespace Topshelf.Runtime.Windows
             }
             catch (Exception ex)
             {
-                // Call the custom exception handler if it is not null
-                //
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Error("Unhandled exception during custom command processing detected", ex);
@@ -296,8 +282,6 @@ namespace Topshelf.Runtime.Windows
 
         void CatchUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            // Call the custom exception handler if it is not null
-            //
             _settings.ExceptionCallback?.Invoke((Exception)e.ExceptionObject);
 
             _log.Fatal("The service threw an unhandled exception", (Exception)e.ExceptionObject);

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -132,7 +132,7 @@ namespace Topshelf.Runtime.Windows
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not start successfully", ex);
 
@@ -156,7 +156,7 @@ namespace Topshelf.Runtime.Windows
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not shut down gracefully", ex);
                 ExitCode = (int)TopshelfExitCode.StopServiceFailed;
@@ -186,7 +186,7 @@ namespace Topshelf.Runtime.Windows
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not pause gracefully", ex);
                 throw;
@@ -208,7 +208,7 @@ namespace Topshelf.Runtime.Windows
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not resume successfully", ex);
                 throw;
@@ -229,7 +229,7 @@ namespace Topshelf.Runtime.Windows
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not shut down gracefully", ex);
                 ExitCode = (int)TopshelfExitCode.StopServiceFailed;
@@ -253,7 +253,7 @@ namespace Topshelf.Runtime.Windows
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not shut down gracefully", ex);
                 ExitCode = (int)TopshelfExitCode.StopServiceFailed;
@@ -275,7 +275,7 @@ namespace Topshelf.Runtime.Windows
             {
                 // Call the custom exception handler if it is not null
                 //
-                _settings.ExceptionHandler?.Invoke(ex);
+                _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Error("Unhandled exception during custom command processing detected", ex);
             }
@@ -298,7 +298,7 @@ namespace Topshelf.Runtime.Windows
         {
             // Call the custom exception handler if it is not null
             //
-            _settings.ExceptionHandler?.Invoke((Exception)e.ExceptionObject);
+            _settings.ExceptionCallback?.Invoke((Exception)e.ExceptionObject);
 
             _log.Fatal("The service threw an unhandled exception", (Exception)e.ExceptionObject);
 


### PR DESCRIPTION
This PR includes a new property on the HostSettings class to allow a user of Topshelf to provide a callback to act upon any exceptions that have occured within the service. The primary driver was to expose any unhandled exceptions, but I added calls to also expose any exceptions in the various service control methods (start, stop, etc).

I did NOT update the docs yet, but am happy to do so once this PR looks okay and is in a state to be merged.