### PR TITLE
Handle Unix signals for shutdown

### DIFF
--- a/src/Topshelf/Topshelf.csproj
+++ b/src/Topshelf/Topshelf.csproj
@@ -45,6 +45,10 @@
     <DocumentationFile>bin\Release\Topshelf.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Posix, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Posix.4.0.0.0\lib\net40\Mono.Posix.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
@@ -242,7 +246,9 @@
   <ItemGroup>
     <EmbeddedResource Include="HelpText.txt" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Topshelf/packages.config
+++ b/src/Topshelf/packages.config
@@ -1,3 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Mono.Posix" version="4.0.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
When running a process as a daemon on Linux (or in aDocker container) the common way to request a shutdown is to send a `SIGINT` or `SIGTERM` signal.

This pull request uses the `Mono.Posix` library to handle such signals in roughly the same way as the existing logic for handling `Ctrl+C`.