### PR TITLE
Enabled support for installing as virtual service account

### DIFF
--- a/src/SolutionVersion.cs
+++ b/src/SolutionVersion.cs
@@ -6,11 +6,16 @@ using System.Reflection;
 [assembly: AssemblyProductAttribute("Topshelf")]
 [assembly: AssemblyVersionAttribute("4.0.0.0")]
 [assembly: AssemblyFileVersionAttribute("4.0.3.0")]
-[assembly: AssemblyInformationalVersionAttribute("4.0.3.0")]
+[assembly: AssemblyInformationalVersionAttribute("4.0.3.0 (develop/0b352d8c)")]
 [assembly: AssemblyCopyrightAttribute("Copyright 2012 Chris Patterson, Dru Sellers, Travis Smith, All rights reserved.")]
 namespace System {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "4.0.0.0";
-        internal const string InformationalVersion = "4.0.3.0";
+        internal const System.String AssemblyTitle = "Topshelf";
+        internal const System.String AssemblyDescription = "Topshelf is an open source project for hosting services without friction. By referencing Topshelf, your console application *becomes* a service installer with a comprehensive set of command-line options for installing, configuring, and running your application as a service.";
+        internal const System.String AssemblyProduct = "Topshelf";
+        internal const System.String AssemblyVersion = "4.0.0.0";
+        internal const System.String AssemblyFileVersion = "4.0.3.0";
+        internal const System.String AssemblyInformationalVersion = "4.0.3.0 (develop/0b352d8c)";
+        internal const System.String AssemblyCopyright = "Copyright 2012 Chris Patterson, Dru Sellers, Travis Smith, All rights reserved.";
     }
 }

--- a/src/Topshelf/Configuration/HostConfigurators/RunAsVirtualAccountHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/RunAsVirtualAccountHostConfigurator.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Topshelf.HostConfigurators
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ServiceProcess;
+    using Builders;
+    using Configurators;
+
+
+    public class RunAsVirtualAccountHostConfigurator :
+        HostBuilderConfigurator
+    {
+        public RunAsVirtualAccountHostConfigurator()
+        {
+        }
+
+        public HostBuilder Configure(HostBuilder builder)
+        {
+            if (builder == null)
+                throw new ArgumentNullException("builder");
+
+            builder.Match<InstallBuilder>(x => x.RunAs("NT SERVICE\\" + x.Settings.ServiceName, "", ServiceAccount.User));
+
+            return builder;
+        }
+
+        public IEnumerable<ValidateResult> Validate()
+        {
+            yield break;
+        }
+    }
+}

--- a/src/Topshelf/Configuration/RunAsExtensions.cs
+++ b/src/Topshelf/Configuration/RunAsExtensions.cs
@@ -30,6 +30,18 @@ namespace Topshelf
             return configurator;
         }
 
+        public static HostConfigurator RunAsVirtualServiceAccount(this HostConfigurator configurator)
+        {
+            if (configurator == null)
+                throw new ArgumentNullException("configurator");
+
+            var runAsConfigurator = new RunAsVirtualAccountHostConfigurator();
+
+            configurator.AddConfigurator(runAsConfigurator);
+
+            return configurator;
+        }
+
         public static HostConfigurator RunAsPrompt(this HostConfigurator configurator)
         {
             if (configurator == null)

--- a/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostEnvironment.cs
@@ -218,13 +218,15 @@ namespace Topshelf.Runtime.Windows
                             installer.ServiceProcessInstaller.Username = settings.Credentials.Username;
                             installer.ServiceProcessInstaller.Account = settings.Credentials.Account;
 
+                            bool gMSA = false;
                             // Group Managed Service Account (gMSA) workaround per
                             // https://connect.microsoft.com/VisualStudio/feedback/details/795196/service-process-installer-should-support-virtual-service-accounts
                             if (settings.Credentials.Account == ServiceAccount.User &&
                                 settings.Credentials.Username != null &&
-                                settings.Credentials.Username.EndsWith("$", StringComparison.InvariantCulture))
+                                ((gMSA = settings.Credentials.Username.EndsWith("$", StringComparison.InvariantCulture)) ||
+                                string.Equals(settings.Credentials.Username, "NT SERVICE\\" + settings.ServiceName, StringComparison.InvariantCulture)))
                             {
-                                _log.InfoFormat("Installing as gMSA {0}.", settings.Credentials.Username);
+                                _log.InfoFormat(gMSA ? "Installing as gMSA {0}." : "Installing as virtual service account", settings.Credentials.Username);
                                 installer.ServiceProcessInstaller.Password = null;
                                 installer.ServiceProcessInstaller
                                     .GetType()

--- a/src/Topshelf/Topshelf.csproj
+++ b/src/Topshelf/Topshelf.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Configuration\DependencyExtensions.cs" />
     <Compile Include="Configuration\HostConfigurators\DependencyHostConfigurator.cs" />
     <Compile Include="Configuration\HostConfigurators\EnvironmentBuilderFactory.cs" />
+    <Compile Include="Configuration\HostConfigurators\RunAsVirtualAccountHostConfigurator.cs" />
     <Compile Include="Configuration\HostConfigurators\SystemOnlyHelpHostConfigurator.cs" />
     <Compile Include="Configuration\HostConfigurators\HostBuilderConfigurator.cs" />
     <Compile Include="Configuration\HostConfigurators\HostBuilderFactory.cs" />


### PR DESCRIPTION
Added a configuration method RunAsVirtualServiceAccount which installs the service as NT SERVICE\service_name.

This leverages the existing workaround for running as Group Managed Service Account.