### PR TITLE
added AdditionalCommandLineArguments for service install

### DIFF
--- a/src/SampleTopshelfService/Program.cs
+++ b/src/SampleTopshelfService/Program.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2007-2013 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software distributed 
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace SampleTopshelfService
 {
@@ -19,8 +19,12 @@ namespace SampleTopshelfService
     {
         static int Main()
         {
+            string company = null;
+
             return (int)HostFactory.Run(x =>
                 {
+                    x.AddCommandLineDefinition("company", s => company = s);
+
                     x.UseLog4Net("log4net.config");
 
                     x.UseAssemblyInfoForServiceInfo();
@@ -55,6 +59,12 @@ namespace SampleTopshelfService
                     x.OnException((exception) =>
                     {
                         Console.WriteLine("Exception thrown - " + exception.Message);
+                    });
+
+                    x.BeforeInstall(ihs =>
+                    {
+                        if (!string.IsNullOrEmpty(company))
+                            ihs.AdditionalCommandLineArguments.Add("company", company);
                     });
                 });
         }

--- a/src/Topshelf/Hosts/InstallHost.cs
+++ b/src/Topshelf/Hosts/InstallHost.cs
@@ -14,6 +14,7 @@ namespace Topshelf.Hosts
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Specialized;
     using System.Linq;
     using System.ServiceProcess;
     using Logging;
@@ -129,6 +130,7 @@ namespace Topshelf.Hosts
             readonly string[] _dependencies;
             readonly HostSettings _settings;
             readonly HostStartMode _startMode;
+            readonly NameValueCollection _additionalCommandLineArguments;
 
             public InstallServiceSettingsImpl(HostSettings settings, Credentials credentials, HostStartMode startMode,
                 string[] dependencies)
@@ -137,6 +139,7 @@ namespace Topshelf.Hosts
                 _settings = settings;
                 _startMode = startMode;
                 _dependencies = dependencies;
+                _additionalCommandLineArguments = new NameValueCollection();
             }
 
             public string Name
@@ -201,6 +204,11 @@ namespace Topshelf.Hosts
             public HostStartMode StartMode
             {
                 get { return _startMode; }
+            }
+
+            public NameValueCollection AdditionalCommandLineArguments
+            {
+                get { return _additionalCommandLineArguments; }
             }
 
             public TimeSpan StartTimeOut

--- a/src/Topshelf/Runtime/InstallHostSettings.cs
+++ b/src/Topshelf/Runtime/InstallHostSettings.cs
@@ -12,11 +12,14 @@
 // specific language governing permissions and limitations under the License.
 namespace Topshelf.Runtime
 {
+    using System.Collections.Specialized;
+
     public interface InstallHostSettings :
         HostSettings
     {
         Credentials Credentials { get; set; }
         string[] Dependencies { get; }
         HostStartMode StartMode { get; }
+        NameValueCollection AdditionalCommandLineArguments { get; }
     }
 }

--- a/src/Topshelf/Runtime/Windows/HostInstaller.cs
+++ b/src/Topshelf/Runtime/Windows/HostInstaller.cs
@@ -13,6 +13,7 @@
 namespace Topshelf.Runtime.Windows
 {
     using System.Collections;
+    using System.Collections.Specialized;
     using System.Configuration.Install;
     using Logging;
     using Microsoft.Win32;
@@ -22,11 +23,11 @@ namespace Topshelf.Runtime.Windows
     {
         static readonly LogWriter _log = HostLogger.Get<HostInstaller>();
 
-        readonly string _arguments;
+        readonly NameValueCollection _arguments;
         readonly Installer[] _installers;
         readonly HostSettings _settings;
 
-        public HostInstaller(HostSettings settings, string arguments, Installer[] installers)
+        public HostInstaller(HostSettings settings, NameValueCollection arguments, Installer[] installers)
         {
             _installers = installers;
             _arguments = arguments;
@@ -56,7 +57,10 @@ namespace Topshelf.Runtime.Windows
 
                 _log.DebugFormat("Service path: {0}", imagePath);
 
-                imagePath += _arguments;
+                foreach (string key in _arguments)
+                {
+                    imagePath += $" -{key} \"{_arguments[key]}\"";
+                }
 
                 _log.DebugFormat("Image path: {0}", imagePath);
 

--- a/src/Topshelf/Runtime/Windows/HostServiceInstaller.cs
+++ b/src/Topshelf/Runtime/Windows/HostServiceInstaller.cs
@@ -1,19 +1,20 @@
 // Copyright 2007-2012 Chris Patterson, Dru Sellers, Travis Smith, et. al.
-//  
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
-// this file except in compliance with the License. You may obtain a copy of the 
-// License at 
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software distributed 
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 namespace Topshelf.Runtime.Windows
 {
     using System;
     using System.Collections;
+    using System.Collections.Specialized;
     using System.Configuration.Install;
     using System.Diagnostics;
     using System.IO;
@@ -30,7 +31,7 @@ namespace Topshelf.Runtime.Windows
         {
             get
             {
-            	return (ServiceProcessInstaller)_installer.Installers[1];      
+            	return (ServiceProcessInstaller)_installer.Installers[1];
             }
         }
 
@@ -131,17 +132,21 @@ namespace Topshelf.Runtime.Windows
 
         static Installer CreateHostInstaller(HostSettings settings, Installer[] installers)
         {
-            string arguments = " ";
+            NameValueCollection arguments = null;
+            var installHostSettings = settings as InstallHostSettings;
+            if (installHostSettings != null)
+            {
+                arguments = installHostSettings.AdditionalCommandLineArguments;
 
-            if (!string.IsNullOrEmpty(settings.InstanceName))
-                arguments += $" -instance \"{settings.InstanceName}\"";
+                if (!string.IsNullOrEmpty(settings.InstanceName))
+                    arguments.Add("instance", settings.InstanceName);
 
-            if (!string.IsNullOrEmpty(settings.DisplayName))
-                arguments += $" -displayname \"{settings.DisplayName}\"";
+                if (!string.IsNullOrEmpty(settings.DisplayName))
+                    arguments.Add("displayname", settings.DisplayName);
 
-            if (!string.IsNullOrEmpty(settings.Name))
-                arguments += $" -servicename \"{settings.Name}\"";
-
+                if (!string.IsNullOrEmpty(settings.Name))
+                    arguments.Add("servicename",settings.Name);
+            }
             return new HostInstaller(settings, arguments, installers);
         }
 


### PR DESCRIPTION
This PR allows to add additional arguments to the service registration.

Up to now only `instance`, `displayname`, and `servicename` are supported. This PR enables the user to specify more arguments in the callback passed to `InstallHostConfiguratorExtensions.BeforeInstall`, e.g.
```c#
x.BeforeInstall(ihs => ihs.AdditionalCommandLineArguments.Add("answer", "42"));
```
The service's `binpath` will now contain `-answer "42"`.

This fixes #330 and #341.