### PR TITLE
use CloseServiceHandle to close handles from Service Control Manager

### DIFF
--- a/src/Topshelf/Runtime/Windows/NativeMethods.cs
+++ b/src/Topshelf/Runtime/Windows/NativeMethods.cs
@@ -141,17 +141,17 @@ namespace Topshelf.Runtime.Windows
 
         [DllImport("advapi32.dll", EntryPoint = "OpenSCManagerW", ExactSpelling = true, CharSet = CharSet.Unicode,
             SetLastError = true)]
-        public static extern SafeTokenHandle OpenSCManager(string machineName, string databaseName, uint dwAccess);
+        public static extern SCMHandle OpenSCManager(string machineName, string databaseName, uint dwAccess);
 
         [DllImport("advapi32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool CloseServiceHandle(SafeTokenHandle hSCObject);
+        public static extern bool CloseServiceHandle(IntPtr hSCObject);
 
         [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        public static extern SafeTokenHandle OpenService(SafeTokenHandle hSCManager, string lpServiceName, uint dwDesiredAccess);
+        public static extern SCMHandle OpenService(SCMHandle hSCManager, string lpServiceName, uint dwDesiredAccess);
 
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern bool ChangeServiceConfig2(SafeTokenHandle serviceHandle, uint infoLevel,
+        public static extern bool ChangeServiceConfig2(SCMHandle serviceHandle, uint infoLevel,
             IntPtr lpInfo);
 
         [DllImport("advapi32.dll", SetLastError = true)]

--- a/src/Topshelf/Runtime/Windows/SCMHandle.cs
+++ b/src/Topshelf/Runtime/Windows/SCMHandle.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2007-2017 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+namespace Topshelf.Runtime.Windows
+{
+    using Microsoft.Win32.SafeHandles;
+
+    public class SCMHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SCMHandle()
+            : base(true) { }
+
+        protected override bool ReleaseHandle()
+        {
+            return NativeMethods.CloseServiceHandle(handle);
+        }
+    }
+}

--- a/src/Topshelf/Runtime/Windows/WindowsServiceRecoveryController.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceRecoveryController.cs
@@ -24,8 +24,8 @@ namespace Topshelf.Runtime.Windows
         [SecurityPermission(SecurityAction.LinkDemand, UnmanagedCode = true)]
         public void SetServiceRecoveryOptions(HostSettings settings, ServiceRecoveryOptions options)
         {
-            SafeTokenHandle scmHandle = null;
-            SafeTokenHandle serviceHandle = null;
+            SCMHandle scmHandle = null;
+            SCMHandle serviceHandle = null;
             IntPtr lpsaActions = IntPtr.Zero;
             IntPtr lpInfo = IntPtr.Zero;
             IntPtr lpFlagInfo = IntPtr.Zero;
@@ -127,9 +127,9 @@ namespace Topshelf.Runtime.Windows
                 if (lpsaActions != IntPtr.Zero)
                     Marshal.FreeHGlobal(lpsaActions);
                 if (serviceHandle != null)
-                    NativeMethods.CloseServiceHandle(serviceHandle);
+                    serviceHandle.Close();
                 if (scmHandle != null)
-                    NativeMethods.CloseServiceHandle(scmHandle);
+                    scmHandle.Close();
             }
         }
 

--- a/src/Topshelf/Topshelf.csproj
+++ b/src/Topshelf/Topshelf.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Runtime\Windows\RestartSystemRecoveryAction.cs" />
     <Compile Include="Runtime\Windows\RunProgramRecoveryAction.cs" />
     <Compile Include="Runtime\Windows\SafeTokenHandle.cs" />
+    <Compile Include="Runtime\Windows\SCMHandle.cs" />
     <Compile Include="Runtime\Windows\ServiceRecoveryAction.cs" />
     <Compile Include="Runtime\Windows\ServiceRecoveryOptions.cs" />
     <Compile Include="Runtime\Windows\WindowsHostEnvironment.cs" />


### PR DESCRIPTION
I experienced `SEHException`s when running the `SampleTopshelfService` demo project. As it turned out, the current code uses `CloseHandle` to close handles returned from SCM methods. Instead, those handles must be closed using `CloseServiceHandle`. See [SCM Handles](https://msdn.microsoft.com/en-us/library/windows/desktop/ms685104(v=vs.85).aspx) for more information.

