### PR TITLE
Add ability to stop service with exit code

### DIFF
--- a/src/Topshelf/HostControl.cs
+++ b/src/Topshelf/HostControl.cs
@@ -31,6 +31,11 @@ namespace Topshelf
         void Stop();
 
         /// <summary>
+        /// Stops the Host, returning the specified exit code
+        /// </summary>
+        void Stop(TopshelfExitCode exitCode);
+
+        /// <summary>
         /// Restarts the Host
         /// </summary>
         void Restart();

--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -148,6 +148,12 @@ namespace Topshelf.Hosts
             _exit.Set();
         }
 
+        void HostControl.Stop(TopshelfExitCode exitCode)
+        {
+            _log.Info($"Service Stop requested with exit code {exitCode}, exiting.");
+            _exitCode = exitCode;
+            _exit.Set();
+        }
 
         void HostControl.Restart()
         {

--- a/src/Topshelf/Hosts/TestHost.cs
+++ b/src/Topshelf/Hosts/TestHost.cs
@@ -84,6 +84,11 @@ namespace Topshelf.Hosts
             _log.Info("Service Stop requested, exiting.");
         }
 
+        void HostControl.Stop(TopshelfExitCode exitCode)
+        {
+            _log.Info($"Service Stop requested with exit code {exitCode}, exiting.");
+        }
+
         void HostControl.Restart()
         {
             _log.Info("Service Restart requested, but we don't support that here, so we are exiting.");

--- a/src/Topshelf/Runtime/ServiceEventsImpl.cs
+++ b/src/Topshelf/Runtime/ServiceEventsImpl.cs
@@ -97,6 +97,11 @@ namespace Topshelf.Runtime
                 _hostControl.Stop();
             }
 
+            public void Stop(TopshelfExitCode exitCode)
+            {
+                _hostControl.Stop(exitCode);
+            }
+
             public void Restart()
             {
                 _hostControl.Restart();

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -95,8 +95,8 @@ namespace Topshelf.Runtime.Windows
             throw new NotImplementedException("This is not done yet, so I'm trying");
         }
 
-        private void InternalStop(TopshelfExitCode? exitCode = null)
-        {
+        private void InternalStop(TopshelfExitCode? exitCode = null)
+        {
             if (CanStop)
             {
                 _log.Debug("Stop requested by hosted service");
@@ -109,7 +109,6 @@ namespace Topshelf.Runtime.Windows
                 _log.Debug("Stop requested by hosted service, but service cannot be stopped at this time");
                 throw new ServiceControlException("The service cannot be stopped at this time");
             }
-
         }
 
         void HostControl.Stop()

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -95,11 +95,13 @@ namespace Topshelf.Runtime.Windows
             throw new NotImplementedException("This is not done yet, so I'm trying");
         }
 
-        void HostControl.Stop()
-        {
+        private void InternalStop(TopshelfExitCode? exitCode = null)
+        {
             if (CanStop)
             {
                 _log.Debug("Stop requested by hosted service");
+                if (exitCode.HasValue)
+                    ExitCode = (int)exitCode.Value;
                 Stop();
             }
             else
@@ -107,6 +109,17 @@ namespace Topshelf.Runtime.Windows
                 _log.Debug("Stop requested by hosted service, but service cannot be stopped at this time");
                 throw new ServiceControlException("The service cannot be stopped at this time");
             }
+
+        }
+
+        void HostControl.Stop()
+        {
+            InternalStop();
+        }
+
+        void HostControl.Stop(TopshelfExitCode exitCode)
+        {
+            InternalStop(exitCode);
         }
 
         protected override void OnStart(string[] args)


### PR DESCRIPTION
This allows services to signal recovery states to the Windows SCM without having to throw an unhandled exception which will spam the event log.