### PR TITLE
Adding extra backslash so it renders correctly

### DIFF
--- a/doc/source/overview/commandline.rst
+++ b/doc/source/overview/commandline.rst
@@ -65,10 +65,10 @@ Examples
     
 **Basic Service Installation**
 
-    MyService.exe install -username:DOMAIN\ServiceAccount -password:itsASecret -servicename:AwesomeService --autostart
+    MyService.exe install -username:DOMAIN\\ServiceAccount -password:itsASecret -servicename:AwesomeService --autostart
     
 **Service Installation with Quoted Arguments**
 
-    MyService.exe install -username "DOMAIN\Service Account" -password:"Its A Secret" -servicename "Awesome Service" --autostart
+    MyService.exe install -username "DOMAIN\\Service Account" -password:"Its A Secret" -servicename "Awesome Service" --autostart
     
     


### PR DESCRIPTION
 On Read-the-Docs and Github, this is rendering as DOMAINServiceAccount with no backslash.