### PR TITLE
Support service recovery configuration times in TimeSpan format

### DIFF
--- a/src/Topshelf/Configuration/HostConfigurators/ServiceRecoveryHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/ServiceRecoveryHostConfigurator.cs
@@ -55,25 +55,40 @@ namespace Topshelf.HostConfigurators
             return builder;
         }
 
+        public ServiceRecoveryConfigurator RestartService(TimeSpan delay)
+        {
+            Options.AddAction(new RestartServiceRecoveryAction(delay));
+
+            return this;
+        }
+
         public ServiceRecoveryConfigurator RestartService(int delayInMinutes)
         {
-            Options.AddAction(new RestartServiceRecoveryAction(delayInMinutes));
+            return RestartService(TimeSpan.FromMinutes(delayInMinutes));
+        }
+
+        public ServiceRecoveryConfigurator RestartComputer(TimeSpan delay, string message)
+        {
+            Options.AddAction(new RestartSystemRecoveryAction(delay, message));
 
             return this;
         }
 
         public ServiceRecoveryConfigurator RestartComputer(int delayInMinutes, string message)
         {
-            Options.AddAction(new RestartSystemRecoveryAction(delayInMinutes, message));
+            return RestartComputer(TimeSpan.FromMinutes(delayInMinutes), message);
+        }
+
+        public ServiceRecoveryConfigurator RunProgram(TimeSpan delay, string command)
+        {
+            Options.AddAction(new RunProgramRecoveryAction(delay, command));
 
             return this;
         }
 
         public ServiceRecoveryConfigurator RunProgram(int delayInMinutes, string command)
         {
-            Options.AddAction(new RunProgramRecoveryAction(delayInMinutes, command));
-
-            return this;
+            return RunProgram(TimeSpan.FromMinutes(delayInMinutes), command);
         }
 
         public ServiceRecoveryConfigurator SetResetPeriod(int days)

--- a/src/Topshelf/Configuration/ServiceRecoveryConfigurator.cs
+++ b/src/Topshelf/Configuration/ServiceRecoveryConfigurator.cs
@@ -17,8 +17,21 @@ namespace Topshelf
         /// <summary>
         ///   Restart the service after waiting the delay period specified
         /// </summary>
+        /// <param name="delay"></param>
+        ServiceRecoveryConfigurator RestartService(System.TimeSpan delay);
+
+        /// <summary>
+        ///   Restart the service after waiting the delay period in minutes
+        /// </summary>
         /// <param name="delayInMinutes"> </param>
         ServiceRecoveryConfigurator RestartService(int delayInMinutes);
+
+        /// <summary>
+        ///   Restart the computer after waiting the delay period specified
+        /// </summary>
+        /// <param name="delay"></param>
+        /// <param name="message"></param>
+        ServiceRecoveryConfigurator RestartComputer(System.TimeSpan delay, string message);
 
         /// <summary>
         ///   Restart the computer after waiting the delay period in minutes
@@ -26,6 +39,13 @@ namespace Topshelf
         /// <param name="delayInMinutes"> </param>
         /// <param name="message"> </param>
         ServiceRecoveryConfigurator RestartComputer(int delayInMinutes, string message);
+
+        /// <summary>
+        ///   Run the command specified
+        /// </summary>
+        /// <param name="delay"></param>
+        /// <param name="command"> </param>
+        ServiceRecoveryConfigurator RunProgram(System.TimeSpan delay, string command);
 
         /// <summary>
         ///   Run the command specified

--- a/src/Topshelf/Runtime/Windows/RestartServiceRecoveryAction.cs
+++ b/src/Topshelf/Runtime/Windows/RestartServiceRecoveryAction.cs
@@ -15,7 +15,7 @@ namespace Topshelf.Runtime.Windows
     public class RestartServiceRecoveryAction :
         ServiceRecoveryAction
     {
-        public RestartServiceRecoveryAction(int delay)
+        public RestartServiceRecoveryAction(System.TimeSpan delay)
             : base(delay)
         {
         }

--- a/src/Topshelf/Runtime/Windows/RestartSystemRecoveryAction.cs
+++ b/src/Topshelf/Runtime/Windows/RestartSystemRecoveryAction.cs
@@ -15,7 +15,7 @@ namespace Topshelf.Runtime.Windows
     public class RestartSystemRecoveryAction :
         ServiceRecoveryAction
     {
-        public RestartSystemRecoveryAction(int delay, string restartMessage)
+        public RestartSystemRecoveryAction(System.TimeSpan delay, string restartMessage)
             : base(delay)
         {
             RestartMessage = restartMessage;

--- a/src/Topshelf/Runtime/Windows/RunProgramRecoveryAction.cs
+++ b/src/Topshelf/Runtime/Windows/RunProgramRecoveryAction.cs
@@ -15,7 +15,7 @@ namespace Topshelf.Runtime.Windows
     public class RunProgramRecoveryAction :
         ServiceRecoveryAction
     {
-        public RunProgramRecoveryAction(int delay, string command)
+        public RunProgramRecoveryAction(System.TimeSpan delay, string command)
             : base(delay)
         {
             Command = command;

--- a/src/Topshelf/Runtime/Windows/ServiceRecoveryAction.cs
+++ b/src/Topshelf/Runtime/Windows/ServiceRecoveryAction.cs
@@ -16,9 +16,9 @@ namespace Topshelf.Runtime.Windows
 
     public abstract class ServiceRecoveryAction
     {
-        protected ServiceRecoveryAction(int delay)
+        protected ServiceRecoveryAction(TimeSpan delay)
         {
-            Delay = (int)TimeSpan.FromMinutes(delay).TotalMilliseconds;
+            Delay = (int)delay.TotalMilliseconds;
         }
 
         public int Delay { get; private set; }


### PR DESCRIPTION
Windows services API enable service recovery by milliseconds and Topshelf API enable on by minutes.
Opened the ServiceRecoveryHostConfigurator interface to enable recovery time by milliseconds.