### PR TITLE
Remove colon from quoted example

### DIFF
--- a/doc/source/overview/commandline.rst
+++ b/doc/source/overview/commandline.rst
@@ -69,6 +69,6 @@ Examples
     
 **Service Installation with Quoted Arguments**
 
-    MyService.exe install -username "DOMAIN\\Service Account" -password:"Its A Secret" -servicename "Awesome Service" --autostart
+    MyService.exe install -username "DOMAIN\\Service Account" -password "Its A Secret" -servicename "Awesome Service" --autostart
     
     


### PR DESCRIPTION
Quoted arguments do not use a colon, the example here would cause the command to fail.