### PR TITLE
NLog Netstandard support  - Fixed nuget dependencies

### DIFF
--- a/src/Topshelf.Log4Net/Topshelf.Log4Net.csproj
+++ b/src/Topshelf.Log4Net/Topshelf.Log4Net.csproj
@@ -16,7 +16,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Topshelf\Topshelf.csproj" />

--- a/src/Topshelf.NLog/Topshelf.NLog.csproj
+++ b/src/Topshelf.NLog/Topshelf.NLog.csproj
@@ -12,6 +12,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>


### PR DESCRIPTION
NetStandard2.0 should not depend on `System `and `System.Core`