### PR TITLE
Port ServiceInstaller infrastructure for .NET Core

### DIFF
--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/ComponentInstaller.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/ComponentInstaller.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Configuration.Install
+{
+    public abstract class ComponentInstaller : Installer
+    {
+        /// <summary>When overridden in a derived class, copies all the properties that are required at install time from the specified component.</summary>
+        /// <param name="component">The component to copy from. </param>
+        public abstract void CopyFromComponent(IComponent component);
+
+        /// <summary>Determines if the specified installer installs the same object as this installer.</summary>
+        /// <returns>true if this installer and the installer specified by the <paramref name="otherInstaller" /> parameter install the same object; otherwise, false.</returns>
+        /// <param name="otherInstaller">The installer to compare. </param>
+        public virtual bool IsEquivalentInstaller(ComponentInstaller otherInstaller)
+        {
+            return false;
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallContext.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallContext.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Configuration.Install
+{
+    public class InstallContext
+    {
+        private StringDictionary parameters;
+
+        public StringDictionary Parameters => this.parameters;
+
+        public InstallContext() : this(null, null)
+        {
+        }
+
+        public InstallContext(string logFilePath, string[] commandLine)
+        {
+            this.parameters = InstallContext.ParseCommandLine(commandLine);
+            if (this.Parameters["logfile"] == null && logFilePath != null)
+            {
+                this.Parameters["logfile"] = logFilePath;
+            }
+        }
+
+        public bool IsParameterTrue(string paramName)
+        {
+            string text = this.Parameters[paramName.ToLower(CultureInfo.InvariantCulture)];
+            if (text == null)
+            {
+                return false;
+            }
+
+            if (string.Compare(text, "true", StringComparison.OrdinalIgnoreCase) != 0
+                && string.Compare(text, "yes", StringComparison.OrdinalIgnoreCase) != 0
+                && string.Compare(text, "1", StringComparison.OrdinalIgnoreCase) != 0)
+            {
+                return "".Equals(text);
+            }
+            return true;
+        }
+
+        public void LogMessage(string message)
+        {
+            try
+            {
+                this.LogMessageHelper(message);
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    this.Parameters["logfile"] = Path.Combine(Path.GetTempPath(), Path.GetFileName(this.Parameters["logfile"]));
+                    this.LogMessageHelper(message);
+                }
+                catch (Exception)
+                {
+                    this.Parameters["logfile"] = null;
+                }
+            }
+            if (!this.IsParameterTrue("LogToConsole") && this.Parameters["logtoconsole"] != null)
+            {
+                return;
+            }
+            Console.WriteLine(message);
+        }
+
+        internal void LogMessageHelper(string message)
+        {
+            StreamWriter streamWriter = null;
+            try
+            {
+                if (!string.IsNullOrEmpty(this.Parameters["logfile"]))
+                {
+                    streamWriter = new StreamWriter(this.Parameters["logfile"], true, Encoding.UTF8);
+                    streamWriter.WriteLine(message);
+                }
+            }
+            finally
+            {
+                if (streamWriter != null)
+                {
+                    streamWriter.Close();
+                }
+            }
+        }
+
+        protected static StringDictionary ParseCommandLine(string[] args)
+        {
+            StringDictionary stringDictionary = new StringDictionary();
+            if (args == null)
+            {
+                return stringDictionary;
+            }
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i].StartsWith("/", StringComparison.Ordinal) || args[i].StartsWith("-", StringComparison.Ordinal))
+                {
+                    args[i] = args[i].Substring(1);
+                }
+                int num = args[i].IndexOf('=');
+                if (num < 0)
+                {
+                    stringDictionary[args[i].ToLower(CultureInfo.InvariantCulture)] = "";
+                }
+                else
+                {
+                    stringDictionary[args[i].Substring(0, num).ToLower(CultureInfo.InvariantCulture)] = args[i].Substring(num + 1);
+                }
+            }
+            return stringDictionary;
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallEventArgs.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+
+namespace System.Configuration.Install
+{
+
+    public delegate void InstallEventHandler(object sender, InstallEventArgs e);
+
+    public class InstallEventArgs
+    {
+        public IDictionary SavedSate { get; }
+
+        public InstallEventArgs()
+        {
+        }
+
+        public InstallEventArgs(IDictionary savedSate)
+        {
+            this.SavedSate = savedSate;
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallException.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallException.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+
+namespace System.Configuration.Install
+{
+    [Serializable]
+    internal class InstallException : SystemException
+    {
+        public InstallException()
+        {
+            base.HResult = -2146232057;
+        }
+
+        public InstallException(string message) : base(message)
+        {
+        }
+
+        public InstallException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected InstallException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/Installer.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/Installer.cs
@@ -1,0 +1,575 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Configuration.Install
+{
+    public class Installer : System.ComponentModel.Component
+    {
+        internal Installer parent;
+        private InstallerCollection installers;
+
+        public InstallContext Context { get; set; }
+        public InstallerCollection Installers
+        {
+            get
+            {
+                if (this.installers == null)
+                {
+                    this.installers = new InstallerCollection(this);
+                }
+
+                return this.installers;
+            }
+        }
+
+        [ResDescription("Desc_Installer_HelpText")]
+        public virtual string HelpText
+        {
+            get
+            {
+                StringBuilder stringBuilder = new StringBuilder();
+                for (int i = 0; i < this.Installers.Count; i++)
+                {
+                    string helpText = this.Installers[i].HelpText;
+                    if (helpText.Length > 0)
+                    {
+                        stringBuilder.Append("\r\n");
+                        stringBuilder.Append(helpText);
+                    }
+                }
+                return stringBuilder.ToString();
+            }
+        }
+
+        [TypeConverter(typeof(InstallerParentConverter))]
+        [ResDescription("Desc_Installer_Parent")]
+        public Installer Parent
+        {
+            get
+            {
+                return this.parent;
+            }
+            set
+            {
+                if (value == this)
+                {
+                    throw new InvalidOperationException(Res.GetString("InstallBadParent"));
+                }
+                if (value != this.parent)
+                {
+                    if (value != null && this.InstallerTreeContains(value))
+                    {
+                        throw new InvalidOperationException(Res.GetString("InstallRecursiveParent"));
+                    }
+                    if (this.parent != null)
+                    {
+                        int num = this.parent.Installers.IndexOf(this);
+                        if (num != -1)
+                        {
+                            this.parent.Installers.RemoveAt(num);
+                        }
+                    }
+                    this.parent = value;
+                    if (this.parent != null && !this.parent.Installers.Contains(this))
+                    {
+                        this.parent.Installers.Add(this);
+                    }
+                }
+            }
+        }
+        public virtual void Commit(IDictionary savedState)
+        {
+            if (savedState == null)
+            {
+                throw new ArgumentException(Res.GetString("InstallNullParameter", "savedState"));
+            }
+            if (savedState["_reserved_lastInstallerAttempted"] != null && savedState["_reserved_nestedSavedStates"] != null)
+            {
+                Exception ex = null;
+                try
+                {
+                    this.OnCommitting(savedState);
+                }
+                catch (Exception ex2)
+                {
+                    this.WriteEventHandlerError(Res.GetString("InstallSeverityWarning"), "OnCommitting", ex2);
+                    this.Context.LogMessage(Res.GetString("InstallCommitException"));
+                    ex = ex2;
+                }
+                int num = (int)savedState["_reserved_lastInstallerAttempted"];
+                IDictionary[] array = (IDictionary[])savedState["_reserved_nestedSavedStates"];
+                if (num + 1 == array.Length && num < this.Installers.Count)
+                {
+                    for (int i = 0; i < this.Installers.Count; i++)
+                    {
+                        this.Installers[i].Context = this.Context;
+                    }
+                    for (int j = 0; j <= num; j++)
+                    {
+                        try
+                        {
+                            this.Installers[j].Commit(array[j]);
+                        }
+                        catch (Exception ex3)
+                        {
+                            if (!this.IsWrappedException(ex3))
+                            {
+                                this.Context.LogMessage(Res.GetString("InstallLogCommitException", this.Installers[j].ToString()));
+                                Installer.LogException(ex3, this.Context);
+                                this.Context.LogMessage(Res.GetString("InstallCommitException"));
+                            }
+                            ex = ex3;
+                        }
+                    }
+                    savedState["_reserved_nestedSavedStates"] = array;
+                    savedState.Remove("_reserved_lastInstallerAttempted");
+                    try
+                    {
+                        this.OnCommitted(savedState);
+                    }
+                    catch (Exception ex4)
+                    {
+                        this.WriteEventHandlerError(Res.GetString("InstallSeverityWarning"), "OnCommitted", ex4);
+                        this.Context.LogMessage(Res.GetString("InstallCommitException"));
+                        ex = ex4;
+                    }
+                    if (ex == null)
+                    {
+                        return;
+                    }
+                    Exception ex5 = ex;
+                    if (!this.IsWrappedException(ex))
+                    {
+                        ex5 = new InstallException(Res.GetString("InstallCommitException"), ex);
+                        ex5.Source = "WrappedExceptionSource";
+                    }
+                    throw ex5;
+                }
+                throw new ArgumentException(Res.GetString("InstallDictionaryCorrupted", "savedState"));
+            }
+            throw new ArgumentException(Res.GetString("InstallDictionaryMissingValues", "savedState"));
+        }
+
+        public virtual void Install(IDictionary stateSaver)
+        {
+            if (stateSaver == null)
+            {
+                throw new ArgumentNullException(nameof(stateSaver));
+            }
+            try
+            {
+                this.OnBeforeInstall(stateSaver);
+            }
+            catch (Exception ex)
+            {
+                this.WriteEventHandlerError(Res.GetString("InstallSeverityError"), "OnBeforeInstall", ex);
+                throw new InvalidOperationException(Res.GetString("InstallEventException", "OnBeforeInstall", base.GetType().FullName), ex);
+            }
+            int num = -1;
+            List<IDictionary> arrayList = new List<IDictionary>();
+            try
+            {
+                for (int i = 0; i < this.Installers.Count; i++)
+                {
+                    this.Installers[i].Context = this.Context;
+                }
+                for (int j = 0; j < this.Installers.Count; j++)
+                {
+                    Installer installer = this.Installers[j];
+                    IDictionary dictionary = new Hashtable();
+                    try
+                    {
+                        num = j;
+                        installer.Install(dictionary);
+                    }
+                    finally
+                    {
+                        arrayList.Add(dictionary);
+                    }
+                }
+            }
+            finally
+            {
+                stateSaver.Add("_reserved_lastInstallerAttempted", num);
+                stateSaver.Add("_reserved_nestedSavedStates", arrayList.ToArray());
+            }
+            try
+            {
+                this.OnAfterInstall(stateSaver);
+            }
+            catch (Exception ex2)
+            {
+                this.WriteEventHandlerError(Res.GetString("InstallSeverityError"), "OnAfterInstall", ex2);
+                throw new InvalidOperationException(Res.GetString("InstallEventException", "OnAfterInstall", base.GetType().FullName), ex2);
+            }
+        }
+
+        public virtual void Rollback(IDictionary savedState)
+        {
+            if (savedState == null)
+            {
+                throw new ArgumentException(Res.GetString("InstallNullParameter", "savedState"));
+            }
+            if (savedState["_reserved_lastInstallerAttempted"] != null && savedState["_reserved_nestedSavedStates"] != null)
+            {
+                Exception ex = null;
+                try
+                {
+                    this.OnBeforeRollback(savedState);
+                }
+                catch (Exception ex2)
+                {
+                    this.WriteEventHandlerError(Res.GetString("InstallSeverityWarning"), "OnBeforeRollback", ex2);
+                    this.Context.LogMessage(Res.GetString("InstallRollbackException"));
+                    ex = ex2;
+                }
+                int num = (int)savedState["_reserved_lastInstallerAttempted"];
+                IDictionary[] array = (IDictionary[])savedState["_reserved_nestedSavedStates"];
+                if (num + 1 == array.Length && num < this.Installers.Count)
+                {
+                    for (int num2 = this.Installers.Count - 1; num2 >= 0; num2--)
+                    {
+                        this.Installers[num2].Context = this.Context;
+                    }
+                    for (int num3 = num; num3 >= 0; num3--)
+                    {
+                        try
+                        {
+                            this.Installers[num3].Rollback(array[num3]);
+                        }
+                        catch (Exception ex3)
+                        {
+                            if (!this.IsWrappedException(ex3))
+                            {
+                                this.Context.LogMessage(Res.GetString("InstallLogRollbackException", this.Installers[num3].ToString()));
+                                Installer.LogException(ex3, this.Context);
+                                this.Context.LogMessage(Res.GetString("InstallRollbackException"));
+                            }
+                            ex = ex3;
+                        }
+                    }
+                    try
+                    {
+                        this.OnAfterRollback(savedState);
+                    }
+                    catch (Exception ex4)
+                    {
+                        this.WriteEventHandlerError(Res.GetString("InstallSeverityWarning"), "OnAfterRollback", ex4);
+                        this.Context.LogMessage(Res.GetString("InstallRollbackException"));
+                        ex = ex4;
+                    }
+                    if (ex == null)
+                    {
+                        return;
+                    }
+                    Exception ex5 = ex;
+                    if (!this.IsWrappedException(ex))
+                    {
+                        ex5 = new InstallException(Res.GetString("InstallRollbackException"), ex);
+                        ex5.Source = "WrappedExceptionSource";
+                    }
+                    throw ex5;
+                }
+                throw new ArgumentException(Res.GetString("InstallDictionaryCorrupted", "savedState"));
+            }
+            throw new ArgumentException(Res.GetString("InstallDictionaryMissingValues", "savedState"));
+        }
+
+        public virtual void Uninstall(IDictionary savedState)
+        {
+            Exception ex = null;
+            try
+            {
+                this.OnBeforeUninstall(savedState);
+            }
+            catch (Exception ex2)
+            {
+                this.WriteEventHandlerError(Res.GetString("InstallSeverityWarning"), "OnBeforeUninstall", ex2);
+                this.Context.LogMessage(Res.GetString("InstallUninstallException"));
+                ex = ex2;
+            }
+            IDictionary[] array;
+            if (savedState != null)
+            {
+                array = (IDictionary[])savedState["_reserved_nestedSavedStates"];
+                if (array != null && array.Length == this.Installers.Count)
+                {
+                    goto IL_0091;
+                }
+                throw new ArgumentException(Res.GetString("InstallDictionaryCorrupted", "savedState"));
+            }
+            array = new IDictionary[this.Installers.Count];
+            goto IL_0091;
+            IL_0091:
+            for (int num = this.Installers.Count - 1; num >= 0; num--)
+            {
+                this.Installers[num].Context = this.Context;
+            }
+            for (int num2 = this.Installers.Count - 1; num2 >= 0; num2--)
+            {
+                try
+                {
+                    this.Installers[num2].Uninstall(array[num2]);
+                }
+                catch (Exception ex3)
+                {
+                    if (!this.IsWrappedException(ex3))
+                    {
+                        this.Context.LogMessage(Res.GetString("InstallLogUninstallException", this.Installers[num2].ToString()));
+                        Installer.LogException(ex3, this.Context);
+                        this.Context.LogMessage(Res.GetString("InstallUninstallException"));
+                    }
+                    ex = ex3;
+                }
+            }
+            try
+            {
+                this.OnAfterUninstall(savedState);
+            }
+            catch (Exception ex4)
+            {
+                this.WriteEventHandlerError(Res.GetString("InstallSeverityWarning"), "OnAfterUninstall", ex4);
+                this.Context.LogMessage(Res.GetString("InstallUninstallException"));
+                ex = ex4;
+            }
+            if (ex == null)
+            {
+                return;
+            }
+            Exception ex5 = ex;
+            if (!this.IsWrappedException(ex))
+            {
+                ex5 = new InstallException(Res.GetString("InstallUninstallException"), ex);
+                ex5.Source = "WrappedExceptionSource";
+            }
+            throw ex5;
+        }
+
+#region Event Handlers
+
+        private InstallEventHandler afterCommitHandler;
+        private InstallEventHandler afterInstallHandler;
+        private InstallEventHandler afterRollbackHandler;
+        private InstallEventHandler afterUninstallHandler;
+        private InstallEventHandler beforeCommitHandler;
+        private InstallEventHandler beforeInstallHandler;
+        private InstallEventHandler beforeRollbackHandler;
+        private InstallEventHandler beforeUninstallHandler;
+
+        public event InstallEventHandler Committed
+        {
+            add
+            {
+                this.afterCommitHandler = (InstallEventHandler)Delegate.Combine(this.afterCommitHandler, value);
+            }
+            remove
+            {
+                this.afterCommitHandler = (InstallEventHandler)Delegate.Remove(this.afterCommitHandler, value);
+            }
+        }
+
+        /// <summary>Occurs after the <see cref="M:System.Configuration.Install.Installer.Install(System.Collections.IDictionary)" /> methods of all the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property have run.</summary>
+        public event InstallEventHandler AfterInstall
+        {
+            add
+            {
+                this.afterInstallHandler = (InstallEventHandler)Delegate.Combine(this.afterInstallHandler, value);
+            }
+            remove
+            {
+                this.afterInstallHandler = (InstallEventHandler)Delegate.Remove(this.afterInstallHandler, value);
+            }
+        }
+
+        /// <summary>Occurs after the installations of all the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property are rolled back.</summary>
+        public event InstallEventHandler AfterRollback
+        {
+            add
+            {
+                this.afterRollbackHandler = (InstallEventHandler)Delegate.Combine(this.afterRollbackHandler, value);
+            }
+            remove
+            {
+                this.afterRollbackHandler = (InstallEventHandler)Delegate.Remove(this.afterRollbackHandler, value);
+            }
+        }
+
+        /// <summary>Occurs after all the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property perform their uninstallation operations.</summary>
+        public event InstallEventHandler AfterUninstall
+        {
+            add
+            {
+                this.afterUninstallHandler = (InstallEventHandler)Delegate.Combine(this.afterUninstallHandler, value);
+            }
+            remove
+            {
+                this.afterUninstallHandler = (InstallEventHandler)Delegate.Remove(this.afterUninstallHandler, value);
+            }
+        }
+
+        /// <summary>Occurs before the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property committ their installations.</summary>
+        public event InstallEventHandler Committing
+        {
+            add
+            {
+                this.beforeCommitHandler = (InstallEventHandler)Delegate.Combine(this.beforeCommitHandler, value);
+            }
+            remove
+            {
+                this.beforeCommitHandler = (InstallEventHandler)Delegate.Remove(this.beforeCommitHandler, value);
+            }
+        }
+
+        /// <summary>Occurs before the <see cref="M:System.Configuration.Install.Installer.Install(System.Collections.IDictionary)" /> method of each installer in the installer collection has run.</summary>
+        public event InstallEventHandler BeforeInstall
+        {
+            add
+            {
+                this.beforeInstallHandler = (InstallEventHandler)Delegate.Combine(this.beforeInstallHandler, value);
+            }
+            remove
+            {
+                this.beforeInstallHandler = (InstallEventHandler)Delegate.Remove(this.beforeInstallHandler, value);
+            }
+        }
+
+        /// <summary>Occurs before the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property are rolled back.</summary>
+        public event InstallEventHandler BeforeRollback
+        {
+            add
+            {
+                this.beforeRollbackHandler = (InstallEventHandler)Delegate.Combine(this.beforeRollbackHandler, value);
+            }
+            remove
+            {
+                this.beforeRollbackHandler = (InstallEventHandler)Delegate.Remove(this.beforeRollbackHandler, value);
+            }
+        }
+
+        /// <summary>Occurs before the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property perform their uninstall operations.</summary>
+        public event InstallEventHandler BeforeUninstall
+        {
+            add
+            {
+                this.beforeUninstallHandler = (InstallEventHandler)Delegate.Combine(this.beforeUninstallHandler, value);
+            }
+            remove
+            {
+                this.beforeUninstallHandler = (InstallEventHandler)Delegate.Remove(this.beforeUninstallHandler, value);
+            }
+        }
+        protected virtual void OnCommitted(IDictionary savedState)
+        {
+            this.afterCommitHandler?.Invoke(this, new InstallEventArgs(savedState));
+        }
+
+        /// <summary>Raises the <see cref="E:System.Configuration.Install.Installer.AfterInstall" /> event.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the state of the computer after all the installers contained in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property have completed their installations. </param>
+        protected virtual void OnAfterInstall(IDictionary savedState)
+        {
+            this.afterInstallHandler?.Invoke(this, new InstallEventArgs(savedState));
+        }
+
+        /// <summary>Raises the <see cref="E:System.Configuration.Install.Installer.AfterRollback" /> event.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the state of the computer after the installers contained in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property are rolled back. </param>
+        protected virtual void OnAfterRollback(IDictionary savedState)
+        {
+            this.afterRollbackHandler?.Invoke(this, new InstallEventArgs(savedState));
+        }
+
+        /// <summary>Raises the <see cref="E:System.Configuration.Install.Installer.AfterUninstall" /> event.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the state of the computer after all the installers contained in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property are uninstalled. </param>
+        protected virtual void OnAfterUninstall(IDictionary savedState)
+        {
+            this.afterUninstallHandler?.Invoke(this, new InstallEventArgs(savedState));
+        }
+
+        /// <summary>Raises the <see cref="E:System.Configuration.Install.Installer.Committing" /> event.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the state of the computer before the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property are committed. </param>
+        protected virtual void OnCommitting(IDictionary savedState)
+        {
+            this.beforeCommitHandler?.Invoke(this, new InstallEventArgs(savedState));
+        }
+
+        /// <summary>Raises the <see cref="E:System.Configuration.Install.Installer.BeforeInstall" /> event.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the state of the computer before the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property are installed. This <see cref="T:System.Collections.IDictionary" /> object should be empty at this point. </param>
+        protected virtual void OnBeforeInstall(IDictionary savedState)
+        {
+            this.beforeInstallHandler?.Invoke(this, new InstallEventArgs(savedState));
+        }
+
+        /// <summary>Raises the <see cref="E:System.Configuration.Install.Installer.BeforeRollback" /> event.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the state of the computer before the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property are rolled back. </param>
+        protected virtual void OnBeforeRollback(IDictionary savedState)
+        {
+            this.beforeRollbackHandler?.Invoke(this, new InstallEventArgs(savedState));
+        }
+
+        /// <summary>Raises the <see cref="E:System.Configuration.Install.Installer.BeforeUninstall" /> event.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the state of the computer before the installers in the <see cref="P:System.Configuration.Install.Installer.Installers" /> property uninstall their installations. </param>
+        protected virtual void OnBeforeUninstall(IDictionary savedState)
+        {
+            this.beforeUninstallHandler?.Invoke(this, new InstallEventArgs(savedState));
+        }
+#endregion
+
+        private void WriteEventHandlerError(string severity, string eventName, Exception e)
+        {
+            this.Context.LogMessage(Res.GetString("InstallLogError", severity, eventName, base.GetType().FullName));
+            Installer.LogException(e, this.Context);
+        }
+
+        internal static void LogException(Exception e, InstallContext context)
+        {
+            bool flag = true;
+            while (e != null)
+            {
+                if (flag)
+                {
+                    context.LogMessage(e.GetType().FullName + ": " + e.Message);
+                    flag = false;
+                }
+                else
+                {
+                    context.LogMessage(Res.GetString("InstallLogInner", e.GetType().FullName, e.Message));
+                }
+                if (context.IsParameterTrue("showcallstack"))
+                {
+                    context.LogMessage(e.StackTrace);
+                }
+                e = e.InnerException;
+            }
+        }
+
+        private bool IsWrappedException(Exception e)
+        {
+            if (e is InstallException && e.Source == "WrappedExceptionSource")
+            {
+                return e.TargetSite.ReflectedType == typeof(Installer);
+            }
+            return false;
+        }
+
+        internal bool InstallerTreeContains(Installer target)
+        {
+            if (this.Installers.Contains(target))
+            {
+                return true;
+            }
+            foreach (Installer installer in this.Installers)
+            {
+                if (installer.InstallerTreeContains(target))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallerCollection.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallerCollection.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+
+namespace System.Configuration.Install
+{
+    public class InstallerCollection : System.Collections.ObjectModel.Collection<Installer>
+    {
+        private readonly Installer owner;
+
+        internal InstallerCollection(Installer owner)
+        {
+            this.owner = owner;
+        }
+
+        public void AddRange(IEnumerable<Installer> value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+            foreach(var item in value)
+            {
+                this.Add(item);
+            }
+        }
+
+        protected override void InsertItem(int index, Installer item)
+        {
+            if (item == this.owner)
+            {
+                throw new ArgumentException(Res.GetString("CantAddSelf"));
+            }
+
+            item.parent = this.owner;
+            base.InsertItem(index, item);
+        }
+
+        protected override void RemoveItem(int index)
+        {
+            this[index].parent = null;
+            base.RemoveItem(index);
+        }
+
+        protected override void SetItem(int index, Installer item)
+        {
+            if (item == this.owner)
+            {
+                throw new ArgumentException(Res.GetString("CantAddSelf"));
+            }
+
+            this[index].parent = null;
+            item.parent = owner;
+            base.SetItem(index, item);
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallerParentConverter.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/InstallerParentConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Configuration.Install
+{
+    internal class InstallerParentConverter : ReferenceConverter
+    {
+        public InstallerParentConverter(Type type)
+            : base(type)
+        {
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            StandardValuesCollection standardValues = base.GetStandardValues(context);
+            object instance = context.Instance;
+            int i = 0;
+            int num = 0;
+            object[] array = new object[standardValues.Count - 1];
+            for (; i < standardValues.Count; i++)
+            {
+                if (standardValues[i] != instance)
+                {
+                    array[num] = standardValues[i];
+                    num++;
+                }
+            }
+            return new StandardValuesCollection(array);
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/Res.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/Res.cs
@@ -1,0 +1,285 @@
+﻿namespace System.Configuration.Install
+{
+    // System.Configuration.Install.Res
+    using System.Configuration.Install;
+    using System.Globalization;
+    using System.Resources;
+    using System.Threading;
+
+    internal sealed class Res
+    {
+        internal const string InstallAbort = "InstallAbort";
+
+        internal const string InstallException = "InstallException";
+
+        internal const string InstallLogContent = "InstallLogContent";
+
+        internal const string InstallFileLocation = "InstallFileLocation";
+
+        internal const string InstallLogParameters = "InstallLogParameters";
+
+        internal const string InstallLogNone = "InstallLogNone";
+
+        internal const string InstallNoPublicInstallers = "InstallNoPublicInstallers";
+
+        internal const string InstallFileNotFound = "InstallFileNotFound";
+
+        internal const string InstallNoInstallerTypes = "InstallNoInstallerTypes";
+
+        internal const string InstallCannotCreateInstance = "InstallCannotCreateInstance";
+
+        internal const string InstallBadParent = "InstallBadParent";
+
+        internal const string InstallRecursiveParent = "InstallRecursiveParent";
+
+        internal const string InstallNullParameter = "InstallNullParameter";
+
+        internal const string InstallDictionaryMissingValues = "InstallDictionaryMissingValues";
+
+        internal const string InstallDictionaryCorrupted = "InstallDictionaryCorrupted";
+
+        internal const string InstallCommitException = "InstallCommitException";
+
+        internal const string InstallRollbackException = "InstallRollbackException";
+
+        internal const string InstallUninstallException = "InstallUninstallException";
+
+        internal const string InstallEventException = "InstallEventException";
+
+        internal const string InstallInstallerNotFound = "InstallInstallerNotFound";
+
+        internal const string InstallSeverityError = "InstallSeverityError";
+
+        internal const string InstallSeverityWarning = "InstallSeverityWarning";
+
+        internal const string InstallLogInner = "InstallLogInner";
+
+        internal const string InstallLogError = "InstallLogError";
+
+        internal const string InstallLogCommitException = "InstallLogCommitException";
+
+        internal const string InstallLogRollbackException = "InstallLogRollbackException";
+
+        internal const string InstallLogUninstallException = "InstallLogUninstallException";
+
+        internal const string InstallRollback = "InstallRollback";
+
+        internal const string InstallAssemblyHelp = "InstallAssemblyHelp";
+
+        internal const string InstallActivityRollingBack = "InstallActivityRollingBack";
+
+        internal const string InstallActivityUninstalling = "InstallActivityUninstalling";
+
+        internal const string InstallActivityCommitting = "InstallActivityCommitting";
+
+        internal const string InstallActivityInstalling = "InstallActivityInstalling";
+
+        internal const string InstallInfoTransacted = "InstallInfoTransacted";
+
+        internal const string InstallInfoBeginInstall = "InstallInfoBeginInstall";
+
+        internal const string InstallInfoException = "InstallInfoException";
+
+        internal const string InstallInfoBeginRollback = "InstallInfoBeginRollback";
+
+        internal const string InstallInfoRollbackDone = "InstallInfoRollbackDone";
+
+        internal const string InstallInfoBeginCommit = "InstallInfoBeginCommit";
+
+        internal const string InstallInfoCommitDone = "InstallInfoCommitDone";
+
+        internal const string InstallInfoTransactedDone = "InstallInfoTransactedDone";
+
+        internal const string InstallInfoBeginUninstall = "InstallInfoBeginUninstall";
+
+        internal const string InstallInfoUninstallDone = "InstallInfoUninstallDone";
+
+        internal const string InstallSavedStateFileCorruptedWarning = "InstallSavedStateFileCorruptedWarning";
+
+        internal const string IncompleteEventLog = "IncompleteEventLog";
+
+        internal const string IncompletePerformanceCounter = "IncompletePerformanceCounter";
+
+        internal const string PerfInvalidCategoryName = "PerfInvalidCategoryName";
+
+        internal const string NotCustomPerformanceCategory = "NotCustomPerformanceCategory";
+
+        internal const string RemovingInstallState = "RemovingInstallState";
+
+        internal const string InstallUnableDeleteFile = "InstallUnableDeleteFile";
+
+        internal const string InstallInitializeException = "InstallInitializeException";
+
+        internal const string InstallFileDoesntExist = "InstallFileDoesntExist";
+
+        internal const string InstallFileDoesntExistCommandLine = "InstallFileDoesntExistCommandLine";
+
+        internal const string WinNTRequired = "WinNTRequired";
+
+        internal const string WrappedExceptionSource = "WrappedExceptionSource";
+
+        internal const string InvalidProperty = "InvalidProperty";
+
+        internal const string InstallRollbackNtRun = "InstallRollbackNtRun";
+
+        internal const string InstallCommitNtRun = "InstallCommitNtRun";
+
+        internal const string InstallUninstallNtRun = "InstallUninstallNtRun";
+
+        internal const string InstallInstallNtRun = "InstallInstallNtRun";
+
+        internal const string InstallHelpMessageStart = "InstallHelpMessageStart";
+
+        internal const string InstallHelpMessageEnd = "InstallHelpMessageEnd";
+
+        internal const string CantAddSelf = "CantAddSelf";
+
+        internal const string Desc_Installer_HelpText = "Desc_Installer_HelpText";
+
+        internal const string Desc_Installer_Parent = "Desc_Installer_Parent";
+
+        internal const string Desc_AssemblyInstaller_Assembly = "Desc_AssemblyInstaller_Assembly";
+
+        internal const string Desc_AssemblyInstaller_CommandLine = "Desc_AssemblyInstaller_CommandLine";
+
+        internal const string Desc_AssemblyInstaller_Path = "Desc_AssemblyInstaller_Path";
+
+        internal const string Desc_AssemblyInstaller_UseNewContext = "Desc_AssemblyInstaller_UseNewContext";
+
+        internal const string NotAnEventLog = "NotAnEventLog";
+
+        internal const string CreatingEventLog = "CreatingEventLog";
+
+        internal const string RestoringEventLog = "RestoringEventLog";
+
+        internal const string RemovingEventLog = "RemovingEventLog";
+
+        internal const string DeletingEventLog = "DeletingEventLog";
+
+        internal const string LocalSourceNotRegisteredWarning = "LocalSourceNotRegisteredWarning";
+
+        internal const string Desc_CategoryResourceFile = "Desc_CategoryResourceFile";
+
+        internal const string Desc_CategoryCount = "Desc_CategoryCount";
+
+        internal const string Desc_Log = "Desc_Log";
+
+        internal const string Desc_MessageResourceFile = "Desc_MessageResourceFile";
+
+        internal const string Desc_ParameterResourceFile = "Desc_ParameterResourceFile";
+
+        internal const string Desc_Source = "Desc_Source";
+
+        internal const string Desc_UninstallAction = "Desc_UninstallAction";
+
+        internal const string NotAPerformanceCounter = "NotAPerformanceCounter";
+
+        internal const string NewCategory = "NewCategory";
+
+        internal const string RestoringPerformanceCounter = "RestoringPerformanceCounter";
+
+        internal const string CreatingPerformanceCounter = "CreatingPerformanceCounter";
+
+        internal const string RemovingPerformanceCounter = "RemovingPerformanceCounter";
+
+        internal const string PCCategoryName = "PCCategoryName";
+
+        internal const string PCCounterName = "PCCounterName";
+
+        internal const string PCInstanceName = "PCInstanceName";
+
+        internal const string PCMachineName = "PCMachineName";
+
+        internal const string PCI_CategoryHelp = "PCI_CategoryHelp";
+
+        internal const string PCI_Counters = "PCI_Counters";
+
+        internal const string PCI_IsMultiInstance = "PCI_IsMultiInstance";
+
+        internal const string PCI_UninstallAction = "PCI_UninstallAction";
+
+        private static Res loader;
+
+        private ResourceManager resources;
+
+        private static CultureInfo Culture
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public static ResourceManager Resources
+        {
+            get
+            {
+                return Res.GetLoader().resources;
+            }
+        }
+
+        internal Res()
+        {
+            this.resources = new ResourceManager("System.Configuration.Install", base.GetType().Assembly);
+        }
+
+        private static Res GetLoader()
+        {
+            if (Res.loader == null)
+            {
+                Res value = new Res();
+                Interlocked.CompareExchange<Res>(ref Res.loader, value, (Res)null);
+            }
+            return Res.loader;
+        }
+
+        public static string GetString(string name, params object[] args)
+        {
+            Res res = Res.GetLoader();
+            if (res == null)
+            {
+                return null;
+            }
+            string @string = res.resources.GetString(name, Res.Culture);
+            if (args != null && args.Length != 0)
+            {
+                for (int i = 0; i < args.Length; i++)
+                {
+                    string text = args[i] as string;
+                    if (text != null && text.Length > 1024)
+                    {
+                        args[i] = text.Substring(0, 1021) + "...";
+                    }
+                }
+                return string.Format(CultureInfo.CurrentCulture, @string, args);
+            }
+            return @string;
+        }
+
+        public static string GetString(string name)
+        {
+            Res res = Res.GetLoader();
+            if (res == null)
+            {
+                return null;
+            }
+            return res.resources.GetString(name, Res.Culture);
+        }
+
+        public static string GetString(string name, out bool usedFallback)
+        {
+            usedFallback = false;
+            return Res.GetString(name);
+        }
+
+        public static object GetObject(string name)
+        {
+            Res res = Res.GetLoader();
+            if (res == null)
+            {
+                return null;
+            }
+            return res.resources.GetObject(name, Res.Culture);
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/ResDescriptionAttribute.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/ResDescriptionAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+
+namespace System.Configuration.Install
+{
+    [AttributeUsage(AttributeTargets.All)]
+    internal sealed class ResDescriptionAttribute : DescriptionAttribute
+    {
+        private bool replaced;
+
+        public override string Description
+        {
+            get
+            {
+                if (!this.replaced)
+                {
+                    this.replaced = true;
+                    base.DescriptionValue = Res.GetString(base.Description);
+                }
+                return base.Description;
+            }
+        }
+
+        public ResDescriptionAttribute(string description)
+            : base(description)
+        {
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/System.Configuration.Install.resx
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/System.Configuration.Install.resx
@@ -1,0 +1,448 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Desc_Installer_Parent" xml:space="preserve">
+    <value>The installer containing the collection that this installer belongs to</value>
+  </data>
+  <data name="NotCustomPerformanceCategory" xml:space="preserve">
+    <value>You cannot create an installer for a system or a nonextensible PerformanceCategory.</value>
+  </data>
+  <data name="InstallInitializeException" xml:space="preserve">
+    <value>Exception occurred while initializing the installation:
+{0}: {1}.</value>
+  </data>
+  <data name="RemovingInstallState" xml:space="preserve">
+    <value>Remove InstallState file because there are no installers.</value>
+  </data>
+  <data name="Desc_Source" xml:space="preserve">
+    <value>The application name (source name) to use when writing to the event log.</value>
+  </data>
+  <data name="InstallSeverityWarning" xml:space="preserve">
+    <value>Warning!</value>
+  </data>
+  <data name="InstallActivityRollingBack" xml:space="preserve">
+    <value>Rolling back assembly '{0}'.</value>
+  </data>
+  <data name="InvalidProperty" xml:space="preserve">
+    <value>Invalid value {1} for property {0}</value>
+  </data>
+  <data name="InstallHelpMessageStart" xml:space="preserve">
+    <value>Usage: InstallUtil [/u | /uninstall] [option [...]] assembly [[option [...]] assembly] [...]]
+
+InstallUtil executes the installers in each given assembly.
+If the /u or /uninstall switch is specified, it uninstalls
+the assemblies, otherwise it installs them. Unlike other
+options, /u applies to all assemblies, regardless of where it
+appears on the command line.
+
+Installation is done in a transactioned way: If one of the
+assemblies fails to install, the installations of all other
+assemblies are rolled back. Uninstall is not transactioned.
+
+Options take the form /switch=[value]. Any option that occurs
+before the name of an assembly will apply to that assembly's
+installation. Options are cumulative but overridable - options
+specified for one assembly will apply to the next as well unless
+the option is specified with a new value. The default for all
+options is empty or false unless otherwise specified.
+
+Options recognized:</value>
+  </data>
+  <data name="PCMachineName" xml:space="preserve">
+    <value>Specifies the machine from where to read the performance data.</value>
+  </data>
+  <data name="InstallLogRollbackException" xml:space="preserve">
+    <value>An exception occurred during the Rollback phase of the {0} installer.</value>
+  </data>
+  <data name="InstallCommitException" xml:space="preserve">
+    <value>An exception occurred during the Commit phase of the installation. This exception will be ignored and installation will continue. However, the application might not function correctly after installation is complete.</value>
+  </data>
+  <data name="InstallLogParameters" xml:space="preserve">
+    <value>Affected parameters are:</value>
+  </data>
+  <data name="InstallLogNone" xml:space="preserve">
+    <value>(none)</value>
+  </data>
+  <data name="Desc_ParameterResourceFile" xml:space="preserve">
+    <value>The path to the dll containing the parameter replacement strings.</value>
+  </data>
+  <data name="InstallNullParameter" xml:space="preserve">
+    <value>The {0} parameter cannot be null.</value>
+  </data>
+  <data name="InstallNoPublicInstallers" xml:space="preserve">
+    <value>No public installers with the RunInstallerAttribute.Yes attribute could be found in the {0} assembly.</value>
+  </data>
+  <data name="InstallHelpMessageEnd" xml:space="preserve">
+    <value>
+Individual installers used within an assembly may recognize other
+options. To learn about these options, run InstallUtil with the paths
+of the assemblies on the command line along with the /? or /help option.
+</value>
+  </data>
+  <data name="CantAddSelf" xml:space="preserve">
+    <value>An installer cannot be added to its own collection.</value>
+  </data>
+  <data name="InstallCannotCreateInstance" xml:space="preserve">
+    <value>Unable to create an instance of the {0} installer type.</value>
+  </data>
+  <data name="IncompleteEventLog" xml:space="preserve">
+    <value>Log and Source properties must be set on the EventLog to create an installer.</value>
+  </data>
+  <data name="InstallInfoCommitDone" xml:space="preserve">
+    <value>The Commit phase completed successfully.</value>
+  </data>
+  <data name="Desc_CategoryResourceFile" xml:space="preserve">
+    <value>The path to the dll containing category names. </value>
+  </data>
+  <data name="InstallActivityInstalling" xml:space="preserve">
+    <value>Installing assembly '{0}'.</value>
+  </data>
+  <data name="WinNTRequired" xml:space="preserve">
+    <value>Feature requires Windows NT.</value>
+  </data>
+  <data name="InstallFileDoesntExist" xml:space="preserve">
+    <value>File {0} does not exist.</value>
+  </data>
+  <data name="InstallException" xml:space="preserve">
+    <value>An exception occurred while trying to find the installers in the {0} assembly.</value>
+  </data>
+  <data name="PCCounterName" xml:space="preserve">
+    <value>Counter name of the performance counter object.</value>
+  </data>
+  <data name="InstallDictionaryMissingValues" xml:space="preserve">
+    <value>The {0} dictionary does not contain the expected values and might have been corrupted.</value>
+  </data>
+  <data name="WrappedExceptionSource" xml:space="preserve">
+    <value>Wrapped Exception from System.Configuration.Install.Installer</value>
+  </data>
+  <data name="InstallFileLocation" xml:space="preserve">
+    <value>The file is located at {0}.</value>
+  </data>
+  <data name="InstallInfoTransacted" xml:space="preserve">
+    <value>Running a transacted installation.</value>
+  </data>
+  <data name="InstallFileNotFound" xml:space="preserve">
+    <value>The {0} file could not be found.</value>
+  </data>
+  <data name="InstallSavedStateFileCorruptedWarning" xml:space="preserve">
+    <value>The file containing the saved state for the {0} assembly, located at {1}, could not be read, and the file might have been corrupted. The uninstall will continue without the saved information.</value>
+  </data>
+  <data name="Desc_Log" xml:space="preserve">
+    <value>The name of the log to read from and write to.</value>
+  </data>
+  <data name="InstallInfoException" xml:space="preserve">
+    <value>An exception occurred during the Install phase.</value>
+  </data>
+  <data name="Desc_AssemblyInstaller_UseNewContext" xml:space="preserve">
+    <value>Value indicating whether to create a new InstallContext object for the assembly's installation</value>
+  </data>
+  <data name="PCI_UninstallAction" xml:space="preserve">
+    <value>Determines behavior of the installer at uninstall time.</value>
+  </data>
+  <data name="PerfInvalidCategoryName" xml:space="preserve">
+    <value>Invalid category name. Its length must be in the range between '{0}' and '{1}'. Double quotes, control characters and leading or trailing spaces are not allowed.</value>
+  </data>
+  <data name="RestoringEventLog" xml:space="preserve">
+    <value>Restoring event log to previous state for source {0}.</value>
+  </data>
+  <data name="Desc_MessageResourceFile" xml:space="preserve">
+    <value>The path to the resource dll containing event messages.</value>
+  </data>
+  <data name="InstallRollback" xml:space="preserve">
+    <value>The installation failed, and the rollback has been performed.</value>
+  </data>
+  <data name="InstallCommitNtRun" xml:space="preserve">
+    <value>Running Commit phase of non-transacted install.</value>
+  </data>
+  <data name="PCCategoryName" xml:space="preserve">
+    <value>Category name of the performance counter object.</value>
+  </data>
+  <data name="NotAPerformanceCounter" xml:space="preserve">
+    <value>PerformanceCounterInstaller can only be used to install objects of type PerformanceCounter.</value>
+  </data>
+  <data name="InstallInfoBeginUninstall" xml:space="preserve">
+    <value>The uninstall is beginning.</value>
+  </data>
+  <data name="InstallSeverityError" xml:space="preserve">
+    <value>Error!</value>
+  </data>
+  <data name="Desc_UninstallAction" xml:space="preserve">
+    <value>The action to take on the Log on uninstall. </value>
+  </data>
+  <data name="InstallUninstallException" xml:space="preserve">
+    <value>An exception occurred while uninstalling. This exception will be ignored and the uninstall will continue. However, the application might not be fully uninstalled after the uninstall is complete.</value>
+  </data>
+  <data name="InstallInstallerNotFound" xml:space="preserve">
+    <value>The given item could not be found in the collection.</value>
+  </data>
+  <data name="Desc_AssemblyInstaller_Path" xml:space="preserve">
+    <value>The path of the assembly to install</value>
+  </data>
+  <data name="InstallRollbackNtRun" xml:space="preserve">
+    <value>Running Rollback phase of non-transacted install.</value>
+  </data>
+  <data name="RemovingEventLog" xml:space="preserve">
+    <value>Removing EventLog source {0}.</value>
+  </data>
+  <data name="NotAnEventLog" xml:space="preserve">
+    <value>EventLogInstaller cannot copy properties from components that are not EventLogs.</value>
+  </data>
+  <data name="InstallDictionaryCorrupted" xml:space="preserve">
+    <value>The {0} dictionary contains inconsistent data and might have been corrupted.</value>
+  </data>
+  <data name="Desc_CategoryCount" xml:space="preserve">
+    <value>The number of categories contained in the CategoryResourceFile. </value>
+  </data>
+  <data name="DeletingEventLog" xml:space="preserve">
+    <value>Deleting event log {0}.</value>
+  </data>
+  <data name="InstallInstallNtRun" xml:space="preserve">
+    <value>Running Install phase of non-transacted install</value>
+  </data>
+  <data name="InstallInfoRollbackDone" xml:space="preserve">
+    <value>The Rollback phase completed successfully.</value>
+  </data>
+  <data name="InstallUninstallNtRun" xml:space="preserve">
+    <value>Running Uninstall phase of non-transacted install</value>
+  </data>
+  <data name="InstallInfoUninstallDone" xml:space="preserve">
+    <value>The uninstall has completed.</value>
+  </data>
+  <data name="Desc_Installer_HelpText" xml:space="preserve">
+    <value>The help text for all the installers in the installer collection</value>
+  </data>
+  <data name="CreatingEventLog" xml:space="preserve">
+    <value>Creating EventLog source {0} in log {1}...</value>
+  </data>
+  <data name="PCI_Counters" xml:space="preserve">
+    <value>The set of counters to install with this category.</value>
+  </data>
+  <data name="InstallAssemblyHelp" xml:space="preserve">
+    <value>Options for installing any assembly:
+/AssemblyName
+ The assembly parameter will be interpreted as an assembly name (Name,
+ Locale, PublicKeyToken, Version). The default is to interpret the
+ assembly parameter as the filename of the assembly on disk.
+
+/LogFile=[filename]
+ File to write progress to. If empty, do not write log. Default
+ is &lt;assemblyname&gt;.InstallLog
+
+/LogToConsole={true|false}
+ If false, suppresses output to the console.
+
+/ShowCallStack
+ If an exception occurs at any point during installation, the call
+ stack will be printed to the log.
+
+/InstallStateDir=[directoryname]
+ Directory in which the .InstallState file will be stored. Default
+ is the directory of the assembly.</value>
+  </data>
+  <data name="InstallNoInstallerTypes" xml:space="preserve">
+    <value>Unable to get installer types in the {0} assembly.</value>
+  </data>
+  <data name="InstallRollbackException" xml:space="preserve">
+    <value>An exception occurred during the Rollback phase of the installation. This exception will be ignored and the rollback will continue. However, the machine might not fully revert to its initial state after the rollback is complete.</value>
+  </data>
+  <data name="InstallInfoBeginRollback" xml:space="preserve">
+    <value>The Rollback phase of the installation is beginning.</value>
+  </data>
+  <data name="PCInstanceName" xml:space="preserve">
+    <value>Instance name of the performance counter object.</value>
+  </data>
+  <data name="InstallActivityUninstalling" xml:space="preserve">
+    <value>Uninstalling assembly '{0}'.</value>
+  </data>
+  <data name="InstallEventException" xml:space="preserve">
+    <value>An exception occurred in the {0} event handler of {1}.</value>
+  </data>
+  <data name="InstallInfoBeginInstall" xml:space="preserve">
+    <value>Beginning the Install phase of the installation.</value>
+  </data>
+  <data name="Desc_AssemblyInstaller_CommandLine" xml:space="preserve">
+    <value>The command line to use when creating a new InstallContext object for the assembly's installation</value>
+  </data>
+  <data name="InstallLogUninstallException" xml:space="preserve">
+    <value>An exception occurred during the uninstallation of the {0} installer.</value>
+  </data>
+  <data name="PCI_CategoryHelp" xml:space="preserve">
+    <value>Help information about this category.</value>
+  </data>
+  <data name="InstallLogError" xml:space="preserve">
+    <value>An exception occurred in the {1} event handler of {2}.</value>
+  </data>
+  <data name="InstallLogInner" xml:space="preserve">
+    <value>The inner exception {0} was thrown with the following error message: {1}.</value>
+  </data>
+  <data name="IncompletePerformanceCounter" xml:space="preserve">
+    <value>CategoryName property must be set on the PerformanceCounter to create an installer.</value>
+  </data>
+  <data name="PCI_IsMultiInstance" xml:space="preserve">
+    <value>Whether this category is a multi-instance or single-instance category.</value>
+  </data>
+  <data name="NewCategory" xml:space="preserve">
+    <value>PerformanceCounterInstaller can only install multiple counters in the same category. To install this counter, create a new instance of PerformanceCounterInstaller.</value>
+  </data>
+  <data name="InstallLogCommitException" xml:space="preserve">
+    <value>An exception occurred during the Commit phase of the {0} installer.</value>
+  </data>
+  <data name="InstallLogContent" xml:space="preserve">
+    <value>See the contents of the log file for the {0} assembly's progress.</value>
+  </data>
+  <data name="InstallRecursiveParent" xml:space="preserve">
+    <value>You cannot set an installer's Parent to an installer that creates a circular dependency.</value>
+  </data>
+  <data name="CreatingPerformanceCounter" xml:space="preserve">
+    <value>Creating performance counter category {0}.</value>
+  </data>
+  <data name="LocalSourceNotRegisteredWarning" xml:space="preserve">
+    <value>Warning: The source {0} is not registered on the local machine.</value>
+  </data>
+  <data name="InstallFileDoesntExistCommandLine" xml:space="preserve">
+    <value>File {0} does not exist. If this parameter is used as an installer option, the format must be /key=[value].</value>
+  </data>
+  <data name="InstallUnableDeleteFile" xml:space="preserve">
+    <value>Unable to delete file {0}.</value>
+  </data>
+  <data name="InstallBadParent" xml:space="preserve">
+    <value>An installer's parent cannot be equal to itself.</value>
+  </data>
+  <data name="RemovingPerformanceCounter" xml:space="preserve">
+    <value>Removing performance counter category {0}.</value>
+  </data>
+  <data name="InstallActivityCommitting" xml:space="preserve">
+    <value>Committing assembly '{0}'.</value>
+  </data>
+  <data name="Desc_AssemblyInstaller_Assembly" xml:space="preserve">
+    <value>The assembly to install</value>
+  </data>
+  <data name="RestoringPerformanceCounter" xml:space="preserve">
+    <value>Restoring performance counter data to previous state for performance counter category {0}.</value>
+  </data>
+  <data name="InstallAbort" xml:space="preserve">
+    <value>Aborting installation for {0}.</value>
+  </data>
+  <data name="InstallInfoTransactedDone" xml:space="preserve">
+    <value>The transacted install has completed.</value>
+  </data>
+  <data name="InstallInfoBeginCommit" xml:space="preserve">
+    <value>The Install phase completed successfully, and the Commit phase is beginning.</value>
+  </data>
+</root>

--- a/src/TopShelf.ServiceInstaller/System.Configuration.Install/TransactedInstaller.cs
+++ b/src/TopShelf.ServiceInstaller/System.Configuration.Install/TransactedInstaller.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Configuration.Install
+{
+    public class TransactedInstaller : Installer
+    {
+        public override void Install(IDictionary savedState)
+        {
+            if (base.Context == null)
+            {
+                base.Context = new InstallContext();
+            }
+            base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoTransacted"));
+            try
+            {
+                bool flag = true;
+                try
+                {
+                    base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoBeginInstall"));
+                    base.Install(savedState);
+                }
+                catch (Exception ex)
+                {
+                    flag = false;
+                    base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoException"));
+                    Installer.LogException(ex, base.Context);
+                    base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoBeginRollback"));
+                    try
+                    {
+                        this.Rollback(savedState);
+                    }
+                    catch (Exception)
+                    {
+                    }
+                    base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoRollbackDone"));
+                    throw new InvalidOperationException(Res.GetString("InstallRollback"), ex);
+                }
+                if (flag)
+                {
+                    base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoBeginCommit"));
+                    try
+                    {
+                        this.Commit(savedState);
+                    }
+                    finally
+                    {
+                        base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoCommitDone"));
+                    }
+                }
+            }
+            finally
+            {
+                base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoTransactedDone"));
+            }
+        }
+
+        public override void Uninstall(IDictionary savedState)
+        {
+            if (base.Context == null)
+            {
+                base.Context = new InstallContext();
+            }
+            base.Context.LogMessage(Environment.NewLine + Environment.NewLine + Res.GetString("InstallInfoBeginUninstall"));
+            try
+            {
+                base.Uninstall(savedState);
+            }
+            finally
+            {
+                base.Context.LogMessage(Environment.NewLine + Res.GetString("InstallInfoUninstallDone"));
+            }
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.Diagnostics/EventLogInstaller.cs
+++ b/src/TopShelf.ServiceInstaller/System.Diagnostics/EventLogInstaller.cs
@@ -1,0 +1,283 @@
+﻿#if NETSTANDARD2_0
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration.Install;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Win32;
+
+namespace System.Diagnostics
+{
+    public class EventLogInstaller : ComponentInstaller
+    {
+        private EventSourceCreationData sourceData = new EventSourceCreationData(null, null);
+
+        private UninstallAction uninstallAction;
+
+        /// <summary>Gets or sets the path of the resource file that contains category strings for the source.</summary>
+        /// <returns>The path of the category resource file. The default is an empty string ("").</returns>
+        [TypeConverter("System.Diagnostics.Design.StringValueConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.Windows.Forms.Design.FileNameEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [ComVisible(false)]
+        [ResDescription("Desc_CategoryResourceFile")]
+        public string CategoryResourceFile
+        {
+            get
+            {
+                return this.sourceData.CategoryResourceFile;
+            }
+            set
+            {
+                this.sourceData.CategoryResourceFile = value;
+            }
+        }
+
+        /// <summary>Gets or sets the number of categories in the category resource file.</summary>
+        /// <returns>The number of categories in the category resource file. The default value is zero.</returns>
+        [ComVisible(false)]
+        [ResDescription("Desc_CategoryCount")]
+        public int CategoryCount
+        {
+            get
+            {
+                return this.sourceData.CategoryCount;
+            }
+            set
+            {
+                this.sourceData.CategoryCount = value;
+            }
+        }
+
+        /// <summary>Gets or sets the name of the log to set the source to.</summary>
+        /// <returns>The name of the log. This can be Application, System, or a custom log name. The default is an empty string ("").</returns>
+        [TypeConverter("System.Diagnostics.Design.StringValueConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [ResDescription("Desc_Log")]
+        public string Log
+        {
+            get
+            {
+                if (this.sourceData.LogName == null && this.sourceData.Source != null)
+                {
+                    this.sourceData.LogName = EventLog.LogNameFromSourceName(this.sourceData.Source, ".");
+                }
+                return this.sourceData.LogName;
+            }
+            set
+            {
+                this.sourceData.LogName = value;
+            }
+        }
+
+        /// <summary>Gets or sets the path of the resource file that contains message formatting strings for the source.</summary>
+        /// <returns>The path of the message resource file. The default is an empty string ("").</returns>
+        [TypeConverter("System.Diagnostics.Design.StringValueConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.Windows.Forms.Design.FileNameEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [ComVisible(false)]
+        [ResDescription("Desc_MessageResourceFile")]
+        public string MessageResourceFile
+        {
+            get
+            {
+                return this.sourceData.MessageResourceFile;
+            }
+            set
+            {
+                this.sourceData.MessageResourceFile = value;
+            }
+        }
+
+        /// <summary>Gets or sets the path of the resource file that contains message parameter strings for the source.</summary>
+        /// <returns>The path of the message parameter resource file. The default is an empty string ("").</returns>
+        [TypeConverter("System.Diagnostics.Design.StringValueConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.Windows.Forms.Design.FileNameEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [ComVisible(false)]
+        [ResDescription("Desc_ParameterResourceFile")]
+        public string ParameterResourceFile
+        {
+            get
+            {
+                return this.sourceData.ParameterResourceFile;
+            }
+            set
+            {
+                this.sourceData.ParameterResourceFile = value;
+            }
+        }
+
+        /// <summary>Gets or sets the source name to register with the log.</summary>
+        /// <returns>The name to register with the event log as a source of entries. The default is an empty string ("").</returns>
+        [TypeConverter("System.Diagnostics.Design.StringValueConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [ResDescription("Desc_Source")]
+        public string Source
+        {
+            get
+            {
+                return this.sourceData.Source;
+            }
+            set
+            {
+                this.sourceData.Source = value;
+            }
+        }
+
+        /// <summary>Gets or sets a value that indicates whether the Installutil.exe (Installer Tool) should remove the event log or leave it in its installed state at uninstall time.</summary>
+        /// <returns>One of the <see cref="T:System.Configuration.Install.UninstallAction" /> values that indicates what state to leave the event log in when the <see cref="T:System.Diagnostics.EventLog" /> is uninstalled. The default is Remove.</returns>
+        /// <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        ///   <see cref="P:System.Diagnostics.EventLogInstaller.UninstallAction" /> contains an invalid value. The only valid values for this property are Remove and NoAction.</exception>
+        [DefaultValue(UninstallAction.Remove)]
+        [ResDescription("Desc_UninstallAction")]
+        public UninstallAction UninstallAction
+        {
+            get
+            {
+                return this.uninstallAction;
+            }
+            set
+            {
+                if (!Enum.IsDefined(typeof(UninstallAction), value))
+                {
+                    throw new InvalidEnumArgumentException("value", (int)value, typeof(UninstallAction));
+                }
+                this.uninstallAction = value;
+            }
+        }
+
+        /// <summary>Copies the property values of an <see cref="T:System.Diagnostics.EventLog" /> component that are required at installation time for an event log.</summary>
+        /// <param name="component">An <see cref="T:System.ComponentModel.IComponent" /> to use as a template for the <see cref="T:System.Diagnostics.EventLogInstaller" />. </param>
+        /// <exception cref="T:System.ArgumentException">The specified component is not an <see cref="T:System.Diagnostics.EventLog" />.-or- The <see cref="P:System.Diagnostics.EventLog.Log" /> or <see cref="P:System.Diagnostics.EventLog.Source" /> property of the specified component is either null or empty. </exception>
+        public override void CopyFromComponent(IComponent component)
+        {
+            EventLog eventLog = component as EventLog;
+            if (eventLog == null)
+            {
+                throw new ArgumentException(Res.GetString("NotAnEventLog"));
+            }
+            if (eventLog.Log != null && !(eventLog.Log == string.Empty) && eventLog.Source != null && !(eventLog.Source == string.Empty))
+            {
+                this.Log = eventLog.Log;
+                this.Source = eventLog.Source;
+                return;
+            }
+            throw new ArgumentException(Res.GetString("IncompleteEventLog"));
+        }
+
+        /// <summary>Performs the installation and writes event log information to the registry.</summary>
+        /// <param name="stateSaver">An <see cref="T:System.Collections.IDictionary" /> used to save information needed to perform a rollback or uninstall operation. </param>
+        /// <exception cref="T:System.PlatformNotSupportedException">The platform the installer is trying to use is not Windows NT 4.0 or later. </exception>
+        /// <exception cref="T:System.ArgumentException">The name specified in the <see cref="P:System.Diagnostics.EventLogInstaller.Source" />  property is already registered for a different event log.</exception>
+        public override void Install(IDictionary stateSaver)
+        {
+            base.Install(stateSaver);
+            base.Context.LogMessage(Res.GetString("CreatingEventLog", this.Source, this.Log));
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                throw new PlatformNotSupportedException(Res.GetString("WinNTRequired"));
+            }
+            stateSaver["baseInstalledAndPlatformOK"] = true;
+            bool flag = EventLog.Exists(this.Log, ".");
+            stateSaver["logExists"] = flag;
+            bool flag2 = EventLog.SourceExists(this.Source, ".");
+            stateSaver["alreadyRegistered"] = flag2;
+            if (flag2 && EventLog.LogNameFromSourceName(this.Source, ".") == this.Log)
+            {
+                return;
+            }
+            EventLog.CreateEventSource(this.sourceData);
+        }
+
+        /// <summary>Determines whether an installer and another specified installer refer to the same source.</summary>
+        /// <returns>true if this installer and the installer specified by the <paramref name="otherInstaller" /> parameter would install or uninstall the same source; otherwise, false.</returns>
+        /// <param name="otherInstaller">The installer to compare. </param>
+        public override bool IsEquivalentInstaller(ComponentInstaller otherInstaller)
+        {
+            EventLogInstaller eventLogInstaller = otherInstaller as EventLogInstaller;
+            if (eventLogInstaller == null)
+            {
+                return false;
+            }
+            return eventLogInstaller.Source == this.Source;
+        }
+
+        /// <summary>Restores the computer to the state it was in before the installation by rolling back the event log information that the installation procedure wrote to the registry.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the pre-installation state of the computer. </param>
+        public override void Rollback(IDictionary savedState)
+        {
+            base.Rollback(savedState);
+            base.Context.LogMessage(Res.GetString("RestoringEventLog", this.Source));
+            if (savedState["baseInstalledAndPlatformOK"] != null)
+            {
+                if (!(bool)savedState["logExists"])
+                {
+                    EventLog.Delete(this.Log, ".");
+                }
+                else
+                {
+                    object obj = savedState["alreadyRegistered"];
+                    bool flag = obj != null && (bool)obj;
+                    if (!flag && EventLog.SourceExists(this.Source, "."))
+                    {
+                        EventLog.DeleteEventSource(this.Source, ".");
+                    }
+                }
+            }
+        }
+
+        /// <summary>Removes an installation by removing event log information from the registry.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the pre-installation state of the computer. </param>
+        public override void Uninstall(IDictionary savedState)
+        {
+            base.Uninstall(savedState);
+            if (this.UninstallAction == UninstallAction.Remove)
+            {
+                base.Context.LogMessage(Res.GetString("RemovingEventLog", this.Source));
+                if (EventLog.SourceExists(this.Source, "."))
+                {
+                    if (string.Compare(this.Log, this.Source, StringComparison.OrdinalIgnoreCase) != 0)
+                    {
+                        EventLog.DeleteEventSource(this.Source, ".");
+                    }
+                }
+                else
+                {
+                    base.Context.LogMessage(Res.GetString("LocalSourceNotRegisteredWarning", this.Source));
+                }
+                RegistryKey registryKey = Registry.LocalMachine;
+                RegistryKey registryKey2 = null;
+                try
+                {
+                    registryKey = registryKey.OpenSubKey("SYSTEM\\CurrentControlSet\\Services\\EventLog", false);
+                    if (registryKey != null)
+                    {
+                        registryKey2 = registryKey.OpenSubKey(this.Log, false);
+                    }
+                    if (registryKey2 != null)
+                    {
+                        string[] subKeyNames = registryKey2.GetSubKeyNames();
+                        if (subKeyNames == null || subKeyNames.Length == 0 || (subKeyNames.Length == 1 && string.Compare(subKeyNames[0], this.Log, StringComparison.OrdinalIgnoreCase) == 0))
+                        {
+                            base.Context.LogMessage(Res.GetString("DeletingEventLog", this.Log));
+                            EventLog.Delete(this.Log, ".");
+                        }
+                    }
+                }
+                finally
+                {
+                    if (registryKey != null)
+                    {
+                        registryKey.Close();
+                    }
+                    if (registryKey2 != null)
+                    {
+                        registryKey2.Close();
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/src/TopShelf.ServiceInstaller/System.Diagnostics/EventLogInstaller.cs
+++ b/src/TopShelf.ServiceInstaller/System.Diagnostics/EventLogInstaller.cs
@@ -1,13 +1,8 @@
-﻿#if NETSTANDARD2_0
-using System;
+﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Configuration.Install;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Win32;
 
 namespace System.Diagnostics
@@ -279,5 +274,3 @@ namespace System.Diagnostics
         }
     }
 }
-
-#endif

--- a/src/TopShelf.ServiceInstaller/System.Diagnostics/UninstallAction.cs
+++ b/src/TopShelf.ServiceInstaller/System.Diagnostics/UninstallAction.cs
@@ -1,5 +1,4 @@
-﻿#if NETSTANDARD2_0
-namespace System.Diagnostics
+﻿namespace System.Diagnostics
 {
     /// <summary>Specifies what an installer should do during an uninstallation.</summary>
     public enum UninstallAction
@@ -10,4 +9,3 @@ namespace System.Diagnostics
         NoAction
     }
 }
-#endif

--- a/src/TopShelf.ServiceInstaller/System.Diagnostics/UninstallAction.cs
+++ b/src/TopShelf.ServiceInstaller/System.Diagnostics/UninstallAction.cs
@@ -1,0 +1,13 @@
+﻿#if NETSTANDARD2_0
+namespace System.Diagnostics
+{
+    /// <summary>Specifies what an installer should do during an uninstallation.</summary>
+    public enum UninstallAction
+    {
+        /// <summary>Removes the resource the installer created.</summary>
+        Remove,
+        /// <summary>Leaves the resource created by the installer as is.</summary>
+        NoAction
+    }
+}
+#endif

--- a/src/TopShelf.ServiceInstaller/System.ServiceProcess/NativeMethods.cs
+++ b/src/TopShelf.ServiceInstaller/System.ServiceProcess/NativeMethods.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.ServiceProcess
+{
+    public partial class NativeMethods
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public class LSA_UNICODE_STRING_withPointer
+        {
+            public short length;
+
+            public short maximumLength;
+
+            public IntPtr pwstr = (IntPtr)0;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public class LSA_UNICODE_STRING
+        {
+            public short length;
+
+            public short maximumLength;
+
+            public string buffer;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public class LSA_OBJECT_ATTRIBUTES
+        {
+            public int length;
+
+            public IntPtr rootDirectory = (IntPtr)0;
+
+            public IntPtr pointerLsaString = (IntPtr)0;
+
+            public int attributes;
+
+            public IntPtr pointerSecurityDescriptor = (IntPtr)0;
+
+            public IntPtr pointerSecurityQualityOfService = (IntPtr)0;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct SERVICE_DELAYED_AUTOSTART_INFO
+        {
+            public bool fDelayedAutostart;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct SERVICE_DESCRIPTION
+        {
+            public IntPtr description;
+        }
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool ChangeServiceConfig2(IntPtr serviceHandle, uint infoLevel, ref SERVICE_DESCRIPTION serviceDesc);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool ChangeServiceConfig2(IntPtr serviceHandle, uint infoLevel, ref SERVICE_DELAYED_AUTOSTART_INFO serviceDesc);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr CreateService(IntPtr databaseHandle, string serviceName, string displayName, int access, int serviceType, int startType, int errorControl, string binaryPath, string loadOrderGroup, IntPtr pTagId, string dependencies, string servicesStartName, string password);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool LookupAccountName(string systemName, string accountName, byte[] sid, int[] sidLen, char[] refDomainName, int[] domNameLen, [In] [Out] int[] sidNameUse);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        public static extern int LsaAddAccountRights(IntPtr policyHandle, byte[] accountSid, LSA_UNICODE_STRING userRights, int countOfRights);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        public static extern int LsaEnumerateAccountRights(IntPtr policyHandle, byte[] accountSid, out IntPtr pLsaUnicodeStringUserRights, out int RightsCount);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        public static extern int LsaOpenPolicy(LSA_UNICODE_STRING systemName, IntPtr pointerObjectAttributes, int desiredAccess, out IntPtr pointerPolicyHandle);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        public static extern int LsaRemoveAccountRights(IntPtr policyHandle, byte[] accountSid, bool allRights, LSA_UNICODE_STRING userRights, int countOfRights);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool GetComputerName(StringBuilder lpBuffer, ref int nSize);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool DeleteService(IntPtr serviceHandle);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr OpenService(IntPtr databaseHandle, string serviceName, int access);
+
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.ServiceProcess/Res.cs
+++ b/src/TopShelf.ServiceInstaller/System.ServiceProcess/Res.cs
@@ -1,0 +1,288 @@
+﻿using System.Globalization;
+using System.Resources;
+using System.Threading;
+
+namespace System.ServiceProcess
+{
+    internal sealed class Res
+    {
+        internal const string RTL = "RTL";
+
+        internal const string FileName = "FileName";
+
+        internal const string ServiceStartedIncorrectly = "ServiceStartedIncorrectly";
+
+        internal const string CallbackHandler = "CallbackHandler";
+
+        internal const string OpenService = "OpenService";
+
+        internal const string StartService = "StartService";
+
+        internal const string StopService = "StopService";
+
+        internal const string PauseService = "PauseService";
+
+        internal const string ResumeService = "ResumeService";
+
+        internal const string ControlService = "ControlService";
+
+        internal const string ServiceName = "ServiceName";
+
+        internal const string ServiceStartType = "ServiceStartType";
+
+        internal const string ServiceDependency = "ServiceDependency";
+
+        internal const string InstallService = "InstallService";
+
+        internal const string InstallError = "InstallError";
+
+        internal const string UserName = "UserName";
+
+        internal const string UserPassword = "UserPassword";
+
+        internal const string ButtonOK = "ButtonOK";
+
+        internal const string ServiceUsage = "ServiceUsage";
+
+        internal const string ServiceNameTooLongForNt4 = "ServiceNameTooLongForNt4";
+
+        internal const string DisplayNameTooLong = "DisplayNameTooLong";
+
+        internal const string NoService = "NoService";
+
+        internal const string NoDisplayName = "NoDisplayName";
+
+        internal const string OpenSC = "OpenSC";
+
+        internal const string Timeout = "Timeout";
+
+        internal const string CannotChangeProperties = "CannotChangeProperties";
+
+        internal const string CannotChangeName = "CannotChangeName";
+
+        internal const string NoServices = "NoServices";
+
+        internal const string NoMachineName = "NoMachineName";
+
+        internal const string BadMachineName = "BadMachineName";
+
+        internal const string NoGivenName = "NoGivenName";
+
+        internal const string CannotStart = "CannotStart";
+
+        internal const string NotAService = "NotAService";
+
+        internal const string NoInstaller = "NoInstaller";
+
+        internal const string UserCanceledInstall = "UserCanceledInstall";
+
+        internal const string UnattendedCannotPrompt = "UnattendedCannotPrompt";
+
+        internal const string InvalidParameter = "InvalidParameter";
+
+        internal const string FailedToUnloadAppDomain = "FailedToUnloadAppDomain";
+
+        internal const string NotInPendingState = "NotInPendingState";
+
+        internal const string ArgsCantBeNull = "ArgsCantBeNull";
+
+        internal const string StartSuccessful = "StartSuccessful";
+
+        internal const string StopSuccessful = "StopSuccessful";
+
+        internal const string PauseSuccessful = "PauseSuccessful";
+
+        internal const string ContinueSuccessful = "ContinueSuccessful";
+
+        internal const string InstallSuccessful = "InstallSuccessful";
+
+        internal const string UninstallSuccessful = "UninstallSuccessful";
+
+        internal const string CommandSuccessful = "CommandSuccessful";
+
+        internal const string StartFailed = "StartFailed";
+
+        internal const string StopFailed = "StopFailed";
+
+        internal const string PauseFailed = "PauseFailed";
+
+        internal const string ContinueFailed = "ContinueFailed";
+
+        internal const string SessionChangeFailed = "SessionChangeFailed";
+
+        internal const string InstallFailed = "InstallFailed";
+
+        internal const string UninstallFailed = "UninstallFailed";
+
+        internal const string CommandFailed = "CommandFailed";
+
+        internal const string ErrorNumber = "ErrorNumber";
+
+        internal const string ShutdownOK = "ShutdownOK";
+
+        internal const string ShutdownFailed = "ShutdownFailed";
+
+        internal const string PowerEventOK = "PowerEventOK";
+
+        internal const string PowerEventFailed = "PowerEventFailed";
+
+        internal const string InstallOK = "InstallOK";
+
+        internal const string TryToStop = "TryToStop";
+
+        internal const string ServiceRemoving = "ServiceRemoving";
+
+        internal const string ServiceRemoved = "ServiceRemoved";
+
+        internal const string HelpText = "HelpText";
+
+        internal const string CantStartFromCommandLine = "CantStartFromCommandLine";
+
+        internal const string CantStartFromCommandLineTitle = "CantStartFromCommandLineTitle";
+
+        internal const string CantRunOnWin9x = "CantRunOnWin9x";
+
+        internal const string CantRunOnWin9xTitle = "CantRunOnWin9xTitle";
+
+        internal const string CantControlOnWin9x = "CantControlOnWin9x";
+
+        internal const string CantInstallOnWin9x = "CantInstallOnWin9x";
+
+        internal const string InstallingService = "InstallingService";
+
+        internal const string StartingService = "StartingService";
+
+        internal const string SBAutoLog = "SBAutoLog";
+
+        internal const string SBServiceName = "SBServiceName";
+
+        internal const string SBServiceDescription = "SBServiceDescription";
+
+        internal const string ServiceControllerDesc = "ServiceControllerDesc";
+
+        internal const string SPCanPauseAndContinue = "SPCanPauseAndContinue";
+
+        internal const string SPCanShutdown = "SPCanShutdown";
+
+        internal const string SPCanStop = "SPCanStop";
+
+        internal const string SPDisplayName = "SPDisplayName";
+
+        internal const string SPDependentServices = "SPDependentServices";
+
+        internal const string SPMachineName = "SPMachineName";
+
+        internal const string SPServiceName = "SPServiceName";
+
+        internal const string SPServicesDependedOn = "SPServicesDependedOn";
+
+        internal const string SPStatus = "SPStatus";
+
+        internal const string SPServiceType = "SPServiceType";
+
+        internal const string SPStartType = "SPStartType";
+
+        internal const string ServiceProcessInstallerAccount = "ServiceProcessInstallerAccount";
+
+        internal const string ServiceInstallerDescription = "ServiceInstallerDescription";
+
+        internal const string ServiceInstallerServicesDependedOn = "ServiceInstallerServicesDependedOn";
+
+        internal const string ServiceInstallerServiceName = "ServiceInstallerServiceName";
+
+        internal const string ServiceInstallerStartType = "ServiceInstallerStartType";
+
+        internal const string ServiceInstallerDelayedAutoStart = "ServiceInstallerDelayedAutoStart";
+
+        internal const string ServiceInstallerDisplayName = "ServiceInstallerDisplayName";
+
+        internal const string Label_SetServiceLogin = "Label_SetServiceLogin";
+
+        internal const string Label_MissmatchedPasswords = "Label_MissmatchedPasswords";
+
+        private static Res loader;
+
+        private ResourceManager resources;
+
+        private static CultureInfo Culture
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public static ResourceManager Resources
+        {
+            get
+            {
+                return Res.GetLoader().resources;
+            }
+        }
+
+        internal Res()
+        {
+            this.resources = new ResourceManager("System.ServiceProcess", base.GetType().Assembly);
+        }
+
+        private static Res GetLoader()
+        {
+            if (Res.loader == null)
+            {
+                Res value = new Res();
+                Interlocked.CompareExchange<Res>(ref Res.loader, value, (Res)null);
+            }
+            return Res.loader;
+        }
+
+        public static string GetString(string name, params object[] args)
+        {
+            Res res = Res.GetLoader();
+            if (res == null)
+            {
+                return null;
+            }
+            string @string = res.resources.GetString(name, Res.Culture);
+            if (args != null && args.Length != 0)
+            {
+                for (int i = 0; i < args.Length; i++)
+                {
+                    string text = args[i] as string;
+                    if (text != null && text.Length > 1024)
+                    {
+                        args[i] = text.Substring(0, 1021) + "...";
+                    }
+                }
+                return string.Format(CultureInfo.CurrentCulture, @string, args);
+            }
+            return @string;
+        }
+
+        public static string GetString(string name)
+        {
+            Res res = Res.GetLoader();
+            if (res == null)
+            {
+                return null;
+            }
+            return res.resources.GetString(name, Res.Culture);
+        }
+
+        public static string GetString(string name, out bool usedFallback)
+        {
+            usedFallback = false;
+            return Res.GetString(name);
+        }
+
+        public static object GetObject(string name)
+        {
+            Res res = Res.GetLoader();
+            if (res == null)
+            {
+                return null;
+            }
+            return res.resources.GetObject(name, Res.Culture);
+        }
+    }
+
+}

--- a/src/TopShelf.ServiceInstaller/System.ServiceProcess/SafeNativeMethods.cs
+++ b/src/TopShelf.ServiceInstaller/System.ServiceProcess/SafeNativeMethods.cs
@@ -1,0 +1,27 @@
+﻿using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace System.ServiceProcess
+{
+    [SuppressUnmanagedCodeSecurity]
+    public partial class SafeNativeMethods
+    {
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        public static extern bool CloseServiceHandle(IntPtr handle);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        public static extern int LsaClose(IntPtr objectHandle);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        public static extern int LsaNtStatusToWinError(int ntStatus);
+
+        [DllImport("advapi32.dll")]
+        public static extern int LsaFreeMemory(IntPtr ptr);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr OpenSCManager(string machineName, string databaseName, int access);
+
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.ServiceProcess/ServiceAccount.cs
+++ b/src/TopShelf.ServiceInstaller/System.ServiceProcess/ServiceAccount.cs
@@ -1,0 +1,14 @@
+﻿namespace System.ServiceProcess
+{
+    public enum ServiceAccount
+    {
+	    /// <summary>An account that acts as a non-privileged user on the local computer, and presents anonymous credentials to any remote server.</summary>
+	    LocalService,
+	    /// <summary>An account that provides extensive local privileges, and presents the computer's credentials to any remote server.</summary>
+	    NetworkService,
+	    /// <summary>An account, used by the service control manager, that has extensive privileges on the local computer and acts as the computer on the network.</summary>
+	    LocalSystem,
+	    /// <summary>An account defined by a specific user on the network. Specifying User for the <see cref="P:System.ServiceProcess.ServiceProcessInstaller.Account" /> member causes the system to prompt for a valid user name and password when the service is installed, unless you set values for both the <see cref="P:System.ServiceProcess.ServiceProcessInstaller.Username" /> and <see cref="P:System.ServiceProcess.ServiceProcessInstaller.Password" /> properties of your <see cref="T:System.ServiceProcess.ServiceProcessInstaller" /> instance.</summary>
+	    User
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.ServiceProcess/ServiceControllerExtensions.cs
+++ b/src/TopShelf.ServiceInstaller/System.ServiceProcess/ServiceControllerExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.ServiceProcess
+{
+    public static class ServiceControllerExtensions
+    {
+        public static bool ValidServiceName(string serviceName)
+        {
+            if (serviceName == null)
+            {
+                return false;
+            }
+            if (serviceName.Length <= 80 && serviceName.Length != 0)
+            {
+                char[] array = serviceName.ToCharArray();
+                foreach (char c in array)
+                {
+                    if (c == '\\' || c == '/')
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.ServiceProcess/ServiceInstaller.cs
+++ b/src/TopShelf.ServiceInstaller/System.ServiceProcess/ServiceInstaller.cs
@@ -1,0 +1,497 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration.Install;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.ServiceProcess
+{
+    public class ServiceInstaller : ComponentInstaller
+    {
+
+        private const string NetworkServiceName = "NT AUTHORITY\\NetworkService";
+
+        private const string LocalServiceName = "NT AUTHORITY\\LocalService";
+
+        //private EventLogInstaller eventLogInstaller;
+
+        private string serviceName = "";
+
+        private string displayName = "";
+
+        private string description = "";
+
+        private string[] servicesDependedOn = new string[0];
+
+        private ServiceStartMode startType = ServiceStartMode.Manual;
+
+        private bool delayedStartMode;
+
+        private static bool environmentChecked;
+
+        private static bool isWin9x;
+
+        /// <summary>Indicates the friendly name that identifies the service to the user.</summary>
+        /// <returns>The name associated with the service, used frequently for interactive tools.</returns>
+        [DefaultValue("")]
+        [ServiceProcessDescription("ServiceInstallerDisplayName")]
+        public string DisplayName
+        {
+            get
+            {
+                return this.displayName;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    value = "";
+                }
+                this.displayName = value;
+            }
+        }
+
+        /// <summary>Gets or sets the description for the service.</summary>
+        /// <returns>The description of the service. The default is an empty string ("").</returns>
+        [DefaultValue("")]
+        [ComVisible(false)]
+        [ServiceProcessDescription("ServiceInstallerDescription")]
+        public string Description
+        {
+            get
+            {
+                return this.description;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    value = "";
+                }
+                this.description = value;
+            }
+        }
+
+        /// <summary>Indicates the services that must be running for this service to run.</summary>
+        /// <returns>An array of services that must be running before the service associated with this installer can run.</returns>
+        [ServiceProcessDescription("ServiceInstallerServicesDependedOn")]
+        public string[] ServicesDependedOn
+        {
+            get
+            {
+                return this.servicesDependedOn;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    value = new string[0];
+                }
+                this.servicesDependedOn = value;
+            }
+        }
+
+        /// <summary>Indicates the name used by the system to identify this service. This property must be identical to the <see cref="P:System.ServiceProcess.ServiceBase.ServiceName" /> of the service you want to install.</summary>
+        /// <returns>The name of the service to be installed. This value must be set before the install utility attempts to install the service.</returns>
+        /// <exception cref="T:System.ArgumentException">The <see cref="P:System.ServiceProcess.ServiceInstaller.ServiceName" /> property is invalid. </exception>
+        [DefaultValue("")]
+        [TypeConverter("System.Diagnostics.Design.StringValueConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [ServiceProcessDescription("ServiceInstallerServiceName")]
+        public string ServiceName
+        {
+            get
+            {
+                return this.serviceName;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    value = "";
+                }
+                if (!ServiceControllerExtensions.ValidServiceName(value))
+                {
+                    throw new ArgumentException(Res.GetString("ServiceName", value, 80.ToString(CultureInfo.CurrentCulture)));
+                }
+                this.serviceName = value;
+                //this.eventLogInstaller.Source = value;
+            }
+        }
+
+        /// <summary>Indicates how and when this service is started.</summary>
+        /// <returns>A <see cref="T:System.ServiceProcess.ServiceStartMode" /> that represents the way the service is started. The default is Manual, which specifies that the service will not automatically start after reboot.</returns>
+        /// <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">The start mode is not a value of the <see cref="T:System.ServiceProcess.ServiceStartMode" /> enumeration.</exception>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode, ControlEvidence" />
+        /// </PermissionSet>
+        [DefaultValue(ServiceStartMode.Manual)]
+        [ServiceProcessDescription("ServiceInstallerStartType")]
+        public ServiceStartMode StartType
+        {
+            get
+            {
+                return this.startType;
+            }
+            set
+            {
+                if (!Enum.IsDefined(typeof(ServiceStartMode), value))
+                {
+                    throw new InvalidEnumArgumentException("value", (int)value, typeof(ServiceStartMode));
+                }
+                if (value != 0 && value != ServiceStartMode.System)
+                {
+                    this.startType = value;
+                    return;
+                }
+                throw new ArgumentException(Res.GetString("ServiceStartType", value));
+            }
+        }
+
+        /// <summary>Gets or sets a value that indicates whether the service should be delayed from starting until other automatically started services are running.</summary>
+        /// <returns>true to delay automatic start of the service; otherwise, false. The default is false.</returns>
+        [DefaultValue(false)]
+        [ServiceProcessDescription("ServiceInstallerDelayedAutoStart")]
+        public bool DelayedAutoStart
+        {
+            get
+            {
+                return this.delayedStartMode;
+            }
+            set
+            {
+                this.delayedStartMode = value;
+            }
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="T:System.ServiceProcess.ServiceInstaller" /> class.</summary>
+        public ServiceInstaller()
+        {
+            //this.eventLogInstaller = new EventLogInstaller();
+            //this.eventLogInstaller.Log = "Application";
+            //this.eventLogInstaller.Source = "";
+            //this.eventLogInstaller.UninstallAction = UninstallAction.Remove;
+            //base.Installers.Add(this.eventLogInstaller);
+        }
+
+        internal static void CheckEnvironment()
+        {
+            if (ServiceInstaller.environmentChecked)
+            {
+                if (!ServiceInstaller.isWin9x)
+                {
+                    return;
+                }
+                throw new PlatformNotSupportedException(Res.GetString("CantControlOnWin9x"));
+            }
+            ServiceInstaller.isWin9x = (Environment.OSVersion.Platform != PlatformID.Win32NT);
+            ServiceInstaller.environmentChecked = true;
+            if (!ServiceInstaller.isWin9x)
+            {
+                return;
+            }
+            throw new PlatformNotSupportedException(Res.GetString("CantInstallOnWin9x"));
+        }
+
+        /// <summary>Copies properties from an instance of <see cref="T:System.ServiceProcess.ServiceBase" /> to this installer.</summary>
+        /// <param name="component">The <see cref="T:System.ComponentModel.IComponent" /> from which to copy. </param>
+        /// <exception cref="T:System.ArgumentException">The component you are associating with this installer does not inherit from <see cref="T:System.ServiceProcess.ServiceBase" />. </exception>
+        public override void CopyFromComponent(IComponent component)
+        {
+            if (!(component is ServiceBase))
+            {
+                throw new ArgumentException(Res.GetString("NotAService"));
+            }
+            ServiceBase serviceBase = (ServiceBase)component;
+            this.ServiceName = serviceBase.ServiceName;
+        }
+
+        /// <summary>Installs the service by writing service application information to the registry. This method is meant to be used by installation tools, which process the appropriate methods automatically.</summary>
+        /// <param name="stateSaver">An <see cref="T:System.Collections.IDictionary" /> that contains the context information associated with the installation. </param>
+        /// <exception cref="T:System.InvalidOperationException">The installation does not contain a <see cref="T:System.ServiceProcess.ServiceProcessInstaller" /> for the executable.-or- The file name for the assembly is null or an empty string.-or- The service name is invalid.-or- The Service Control Manager could not be opened. </exception>
+        /// <exception cref="T:System.ArgumentException">The display name for the service is more than 255 characters in length.</exception>
+        /// <exception cref="T:System.ComponentModel.Win32Exception">The system could not generate a handle to the service. -or-A service with that name is already installed.</exception>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />
+        ///   <IPermission class="System.Security.Permissions.UIPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        /// </PermissionSet>
+        public override void Install(IDictionary stateSaver)
+        {
+            base.Context.LogMessage(Res.GetString("InstallingService", this.ServiceName));
+            try
+            {
+                ServiceInstaller.CheckEnvironment();
+                string servicesStartName = null;
+                string password = null;
+                ServiceProcessInstaller serviceProcessInstaller = null;
+                if (base.Parent is ServiceProcessInstaller)
+                {
+                    serviceProcessInstaller = (ServiceProcessInstaller)base.Parent;
+                }
+                else
+                {
+                    int num = 0;
+                    while (num < base.Parent.Installers.Count)
+                    {
+                        if (!(base.Parent.Installers[num] is ServiceProcessInstaller))
+                        {
+                            num++;
+                            continue;
+                        }
+                        serviceProcessInstaller = (ServiceProcessInstaller)base.Parent.Installers[num];
+                        break;
+                    }
+                }
+                if (serviceProcessInstaller == null)
+                {
+                    throw new InvalidOperationException(Res.GetString("NoInstaller"));
+                }
+                switch (serviceProcessInstaller.Account)
+                {
+                    case ServiceAccount.LocalService:
+                        servicesStartName = "NT AUTHORITY\\LocalService";
+                        break;
+                    case ServiceAccount.NetworkService:
+                        servicesStartName = "NT AUTHORITY\\NetworkService";
+                        break;
+                    case ServiceAccount.User:
+                        servicesStartName = serviceProcessInstaller.Username;
+                        password = serviceProcessInstaller.Password;
+                        break;
+                }
+                string text = base.Context.Parameters["assemblypath"];
+                if (string.IsNullOrEmpty(text))
+                {
+                    throw new InvalidOperationException(Res.GetString("FileName"));
+                }
+                if (text.IndexOf('"') == -1)
+                {
+                    text = "\"" + text + "\"";
+                }
+                if (!ServiceInstaller.ValidateServiceName(this.ServiceName))
+                {
+                    throw new InvalidOperationException(Res.GetString("ServiceName", this.ServiceName, 80.ToString(CultureInfo.CurrentCulture)));
+                }
+                if (this.DisplayName.Length > 255)
+                {
+                    throw new ArgumentException(Res.GetString("DisplayNameTooLong", this.DisplayName));
+                }
+                string dependencies = null;
+                if (this.ServicesDependedOn.Length != 0)
+                {
+                    StringBuilder stringBuilder = new StringBuilder();
+                    for (int i = 0; i < this.ServicesDependedOn.Length; i++)
+                    {
+                        string text2 = this.ServicesDependedOn[i];
+                        try
+                        {
+                            text2 = new ServiceController(text2, ".").ServiceName;
+                        }
+                        catch
+                        {
+                        }
+                        stringBuilder.Append(text2);
+                        stringBuilder.Append('\0');
+                    }
+                    stringBuilder.Append('\0');
+                    dependencies = stringBuilder.ToString();
+                }
+                IntPtr intPtr = SafeNativeMethods.OpenSCManager(null, null, 983103);
+                IntPtr intPtr2 = IntPtr.Zero;
+                if (intPtr == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException(Res.GetString("OpenSC", "."), new Win32Exception());
+                }
+                int serviceType = 16;
+                int num2 = 0;
+                for (int j = 0; j < base.Parent.Installers.Count; j++)
+                {
+                    if (base.Parent.Installers[j] is ServiceInstaller)
+                    {
+                        num2++;
+                        if (num2 > 1)
+                        {
+                            break;
+                        }
+                    }
+                }
+                if (num2 > 1)
+                {
+                    serviceType = 32;
+                }
+                try
+                {
+                    intPtr2 = NativeMethods.CreateService(intPtr, this.ServiceName, this.DisplayName, 983551, serviceType, (int)this.StartType, 1, text, null, IntPtr.Zero, dependencies, servicesStartName, password);
+                    if (intPtr2 == IntPtr.Zero)
+                    {
+                        throw new Win32Exception();
+                    }
+                    if (this.Description.Length != 0)
+                    {
+                        NativeMethods.SERVICE_DESCRIPTION sERVICE_DESCRIPTION = default(NativeMethods.SERVICE_DESCRIPTION);
+                        sERVICE_DESCRIPTION.description = Marshal.StringToHGlobalUni(this.Description);
+                        bool num3 = NativeMethods.ChangeServiceConfig2(intPtr2, 1u, ref sERVICE_DESCRIPTION);
+                        Marshal.FreeHGlobal(sERVICE_DESCRIPTION.description);
+                        if (!num3)
+                        {
+                            throw new Win32Exception();
+                        }
+                    }
+                    if (Environment.OSVersion.Version.Major > 5 && this.StartType == ServiceStartMode.Automatic)
+                    {
+                        NativeMethods.SERVICE_DELAYED_AUTOSTART_INFO sERVICE_DELAYED_AUTOSTART_INFO = default(NativeMethods.SERVICE_DELAYED_AUTOSTART_INFO);
+                        sERVICE_DELAYED_AUTOSTART_INFO.fDelayedAutostart = this.DelayedAutoStart;
+                        if (!NativeMethods.ChangeServiceConfig2(intPtr2, 3u, ref sERVICE_DELAYED_AUTOSTART_INFO))
+                        {
+                            throw new Win32Exception();
+                        }
+                    }
+                    stateSaver["installed"] = true;
+                }
+                finally
+                {
+                    if (intPtr2 != IntPtr.Zero)
+                    {
+                        SafeNativeMethods.CloseServiceHandle(intPtr2);
+                    }
+                    SafeNativeMethods.CloseServiceHandle(intPtr);
+                }
+                base.Context.LogMessage(Res.GetString("InstallOK", this.ServiceName));
+            }
+            finally
+            {
+                base.Install(stateSaver);
+            }
+        }
+
+        /// <summary>Indicates whether two installers would install the same service.</summary>
+        /// <returns>true if calling <see cref="M:System.ServiceProcess.ServiceInstaller.Install(System.Collections.IDictionary)" /> on both of these installers would result in installing the same service; otherwise, false.</returns>
+        /// <param name="otherInstaller">A <see cref="T:System.Configuration.Install.ComponentInstaller" /> to which you are comparing the current installer. </param>
+        public override bool IsEquivalentInstaller(ComponentInstaller otherInstaller)
+        {
+            ServiceInstaller serviceInstaller = otherInstaller as ServiceInstaller;
+            if (serviceInstaller == null)
+            {
+                return false;
+            }
+            return serviceInstaller.ServiceName == this.ServiceName;
+        }
+
+        private void RemoveService()
+        {
+            base.Context.LogMessage(Res.GetString("ServiceRemoving", this.ServiceName));
+            IntPtr intPtr = SafeNativeMethods.OpenSCManager(null, null, 983103);
+            if (intPtr == IntPtr.Zero)
+            {
+                throw new Win32Exception();
+            }
+            IntPtr intPtr2 = IntPtr.Zero;
+            try
+            {
+                intPtr2 = NativeMethods.OpenService(intPtr, this.ServiceName, 65536);
+                if (intPtr2 == IntPtr.Zero)
+                {
+                    throw new Win32Exception();
+                }
+                NativeMethods.DeleteService(intPtr2);
+            }
+            finally
+            {
+                if (intPtr2 != IntPtr.Zero)
+                {
+                    SafeNativeMethods.CloseServiceHandle(intPtr2);
+                }
+                SafeNativeMethods.CloseServiceHandle(intPtr);
+            }
+            base.Context.LogMessage(Res.GetString("ServiceRemoved", this.ServiceName));
+            try
+            {
+                using (ServiceController serviceController = new ServiceController(this.ServiceName))
+                {
+                    if (serviceController.Status != ServiceControllerStatus.Stopped)
+                    {
+                        base.Context.LogMessage(Res.GetString("TryToStop", this.ServiceName));
+                        serviceController.Stop();
+                        int num = 10;
+                        serviceController.Refresh();
+                        while (serviceController.Status != ServiceControllerStatus.Stopped && num > 0)
+                        {
+                            Thread.Sleep(1000);
+                            serviceController.Refresh();
+                            num--;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+            }
+            Thread.Sleep(5000);
+        }
+
+        /// <summary>Rolls back service application information written to the registry by the installation procedure. This method is meant to be used by installation tools, which process the appropriate methods automatically.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the context information associated with the installation. </param>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />
+        ///   <IPermission class="System.ServiceProcess.ServiceControllerPermission, System.ServiceProcess, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" version="1" Unrestricted="true" />
+        /// </PermissionSet>
+        public override void Rollback(IDictionary savedState)
+        {
+            base.Rollback(savedState);
+            object obj = savedState["installed"];
+            if (obj != null && (bool)obj)
+            {
+                this.RemoveService();
+            }
+        }
+
+        private bool ShouldSerializeServicesDependedOn()
+        {
+            if (this.servicesDependedOn != null && this.servicesDependedOn.Length != 0)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>Uninstalls the service by removing information about it from the registry.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the context information associated with the installation. </param>
+        /// <exception cref="T:System.ComponentModel.Win32Exception">The Service Control Manager could not be opened.-or- The system could not get a handle to the service. </exception>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />
+        ///   <IPermission class="System.ServiceProcess.ServiceControllerPermission, System.ServiceProcess, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" version="1" Unrestricted="true" />
+        /// </PermissionSet>
+        public override void Uninstall(IDictionary savedState)
+        {
+            base.Uninstall(savedState);
+            this.RemoveService();
+        }
+
+        private static bool ValidateServiceName(string name)
+        {
+            if (name != null && name.Length != 0 && name.Length <= 80)
+            {
+                char[] array = name.ToCharArray();
+                for (int i = 0; i < array.Length; i++)
+                {
+                    if (array[i] < ' ' || array[i] == '/' || array[i] == '\\')
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+    }
+}
+

--- a/src/TopShelf.ServiceInstaller/System.ServiceProcess/ServiceProcessInstaller.cs
+++ b/src/TopShelf.ServiceInstaller/System.ServiceProcess/ServiceProcessInstaller.cs
@@ -1,0 +1,400 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration.Install;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.ServiceProcess
+{
+    public class ServiceProcessInstaller : ComponentInstaller
+    {
+        private ServiceAccount serviceAccount = ServiceAccount.User;
+
+        private bool haveLoginInfo;
+
+        private string password;
+
+        private string username;
+
+        private static bool helpPrinted;
+
+        /// <summary>Gets help text displayed for service installation options.</summary>
+        /// <returns>Help text that provides a description of the steps for setting the user name and password in order to run the service under a particular account.</returns>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode, ControlEvidence" />
+        /// </PermissionSet>
+        public override string HelpText
+        {
+            get
+            {
+                if (ServiceProcessInstaller.helpPrinted)
+                {
+                    return base.HelpText;
+                }
+                ServiceProcessInstaller.helpPrinted = true;
+                return Res.GetString("HelpText") + "\r\n" + base.HelpText;
+            }
+        }
+
+        /// <summary>Gets or sets the password associated with the user account under which the service application runs.</summary>
+        /// <returns>The password associated with the account under which the service should run. The default is an empty string (""). The property is not public, and is never serialized.</returns>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.EnvironmentPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode, ControlEvidence" />
+        ///   <IPermission class="System.Security.Permissions.UIPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Diagnostics.PerformanceCounterPermission, System, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        /// </PermissionSet>
+        [Browsable(false)]
+        public string Password
+        {
+            get
+            {
+                if (!this.haveLoginInfo)
+                {
+                    this.GetLoginInfo();
+                }
+                return this.password;
+            }
+            set
+            {
+                this.haveLoginInfo = false;
+                this.password = value;
+            }
+        }
+
+        /// <summary>Gets or sets the type of account under which to run this service application.</summary>
+        /// <returns>A <see cref="T:System.ServiceProcess.ServiceAccount" /> that defines the type of account under which the system runs this service. The default is User.</returns>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.EnvironmentPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode, ControlEvidence" />
+        ///   <IPermission class="System.Security.Permissions.UIPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Diagnostics.PerformanceCounterPermission, System, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        /// </PermissionSet>
+        [DefaultValue(ServiceAccount.User)]
+        [ServiceProcessDescription("ServiceProcessInstallerAccount")]
+        public ServiceAccount Account
+        {
+            get
+            {
+                if (!this.haveLoginInfo)
+                {
+                    this.GetLoginInfo();
+                }
+                return this.serviceAccount;
+            }
+            set
+            {
+                this.haveLoginInfo = false;
+                this.serviceAccount = value;
+            }
+        }
+
+        /// <summary>Gets or sets the user account under which the service application will run.</summary>
+        /// <returns>The account under which the service should run. The default is an empty string ("").</returns>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.EnvironmentPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode, ControlEvidence" />
+        ///   <IPermission class="System.Security.Permissions.UIPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        ///   <IPermission class="System.Diagnostics.PerformanceCounterPermission, System, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        /// </PermissionSet>
+        [TypeConverter("System.Diagnostics.Design.StringValueConverter, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Browsable(false)]
+        public string Username
+        {
+            get
+            {
+                if (!this.haveLoginInfo)
+                {
+                    this.GetLoginInfo();
+                }
+                return this.username;
+            }
+            set
+            {
+                this.haveLoginInfo = false;
+                this.username = value;
+            }
+        }
+
+        private static bool AccountHasRight(IntPtr policyHandle, byte[] accountSid, string rightName)
+        {
+            IntPtr intPtr = (IntPtr)0;
+            int num = 0;
+            int num2 = NativeMethods.LsaEnumerateAccountRights(policyHandle, accountSid, out intPtr, out num);
+            switch (num2)
+            {
+                case -1073741772:
+                    return false;
+                default:
+                    throw new Win32Exception(SafeNativeMethods.LsaNtStatusToWinError(num2));
+                case 0:
+                    {
+                        bool result = false;
+                        try
+                        {
+                            IntPtr intPtr2 = intPtr;
+                            for (int i = 0; i < num; i++)
+                            {
+                                NativeMethods.LSA_UNICODE_STRING_withPointer lSA_UNICODE_STRING_withPointer = new NativeMethods.LSA_UNICODE_STRING_withPointer();
+                                Marshal.PtrToStructure(intPtr2, (object)lSA_UNICODE_STRING_withPointer);
+                                char[] array = new char[lSA_UNICODE_STRING_withPointer.length / 2];
+                                Marshal.Copy(lSA_UNICODE_STRING_withPointer.pwstr, array, 0, array.Length);
+                                if (string.Compare(new string(array, 0, array.Length), rightName, StringComparison.Ordinal) == 0)
+                                {
+                                    return true;
+                                }
+                                intPtr2 = (IntPtr)((long)intPtr2 + Marshal.SizeOf(typeof(NativeMethods.LSA_UNICODE_STRING)));
+                            }
+                            return result;
+                        }
+                        finally
+                        {
+                            SafeNativeMethods.LsaFreeMemory(intPtr);
+                        }
+                    }
+            }
+        }
+
+        /// <summary>Implements the base class <see cref="M:System.Configuration.Install.ComponentInstaller.CopyFromComponent(System.ComponentModel.IComponent)" /> method with no <see cref="T:System.ServiceProcess.ServiceProcessInstaller" /> class-specific behavior.</summary>
+        /// <param name="comp">The <see cref="T:System.ComponentModel.IComponent" /> that represents the service process. </param>
+        public override void CopyFromComponent(IComponent comp)
+        {
+        }
+
+        private byte[] GetAccountSid(string accountName)
+        {
+            byte[] array = new byte[256];
+            int[] array2 = new int[1]
+            {
+            array.Length
+            };
+            char[] array3 = new char[1024];
+            int[] domNameLen = new int[1]
+            {
+            array3.Length
+            };
+            int[] sidNameUse = new int[1];
+            if (accountName.Substring(0, 2) == ".\\")
+            {
+                StringBuilder stringBuilder = new StringBuilder(32);
+                int num = 32;
+                if (!NativeMethods.GetComputerName(stringBuilder, ref num))
+                {
+                    throw new Win32Exception();
+                }
+                accountName = stringBuilder + accountName.Substring(1);
+            }
+            if (!NativeMethods.LookupAccountName(null, accountName, array, array2, array3, domNameLen, sidNameUse))
+            {
+                throw new Win32Exception();
+            }
+            byte[] array4 = new byte[array2[0]];
+            Array.Copy(array, 0, array4, 0, array2[0]);
+            return array4;
+        }
+
+        private void GetLoginInfo()
+        {
+            if (base.Context != null && !base.DesignMode && !this.haveLoginInfo)
+            {
+                this.haveLoginInfo = true;
+                if (this.serviceAccount != ServiceAccount.User)
+                {
+                    return;
+                }
+                if (base.Context.Parameters.ContainsKey("username"))
+                {
+                    this.username = base.Context.Parameters["username"];
+                }
+                if (base.Context.Parameters.ContainsKey("password"))
+                {
+                    this.password = base.Context.Parameters["password"];
+                }
+                if (this.username != null && this.username.Length != 0 && this.password != null)
+                {
+                    return;
+                }
+                if (!base.Context.Parameters.ContainsKey("unattended"))
+                {
+                    throw new PlatformNotSupportedException();
+                    //using (ServiceInstallerDialog serviceInstallerDialog = new ServiceInstallerDialog())
+                    //{
+                    //    if (this.username != null)
+                    //    {
+                    //        serviceInstallerDialog.Username = this.username;
+                    //    }
+                    //    serviceInstallerDialog.ShowDialog();
+                    //    switch (serviceInstallerDialog.Result)
+                    //    {
+                    //        case ServiceInstallerDialogResult.Canceled:
+                    //            throw new InvalidOperationException(Res.GetString("UserCanceledInstall", base.Context.Parameters["assemblypath"]));
+                    //        case ServiceInstallerDialogResult.UseSystem:
+                    //            this.username = null;
+                    //            this.password = null;
+                    //            this.serviceAccount = ServiceAccount.LocalSystem;
+                    //            break;
+                    //        case ServiceInstallerDialogResult.OK:
+                    //            this.username = serviceInstallerDialog.Username;
+                    //            this.password = serviceInstallerDialog.Password;
+                    //            break;
+                    //    }
+                    //}
+                    //return;
+                }
+                throw new InvalidOperationException(Res.GetString("UnattendedCannotPrompt", base.Context.Parameters["assemblypath"]));
+            }
+        }
+
+        private static void GrantAccountRight(IntPtr policyHandle, byte[] accountSid, string rightName)
+        {
+            NativeMethods.LSA_UNICODE_STRING lSA_UNICODE_STRING = new NativeMethods.LSA_UNICODE_STRING();
+            lSA_UNICODE_STRING.buffer = rightName;
+            NativeMethods.LSA_UNICODE_STRING lSA_UNICODE_STRING2 = lSA_UNICODE_STRING;
+            lSA_UNICODE_STRING2.length = (short)(lSA_UNICODE_STRING2.buffer.Length * 2);
+            NativeMethods.LSA_UNICODE_STRING lSA_UNICODE_STRING3 = lSA_UNICODE_STRING;
+            lSA_UNICODE_STRING3.maximumLength = lSA_UNICODE_STRING3.length;
+            int num = NativeMethods.LsaAddAccountRights(policyHandle, accountSid, lSA_UNICODE_STRING, 1);
+            if (num == 0)
+            {
+                return;
+            }
+            throw new Win32Exception(SafeNativeMethods.LsaNtStatusToWinError(num));
+        }
+
+        /// <summary>Writes service application information to the registry. This method is meant to be used by installation tools, which call the appropriate methods automatically.</summary>
+        /// <param name="stateSaver">An <see cref="T:System.Collections.IDictionary" /> that contains the context information associated with the installation. </param>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="stateSaver" /> is null. </exception>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />
+        ///   <IPermission class="System.Security.Permissions.UIPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true" />
+        /// </PermissionSet>
+        public override void Install(IDictionary stateSaver)
+        {
+            try
+            {
+                ServiceInstaller.CheckEnvironment();
+                try
+                {
+                    if (!this.haveLoginInfo)
+                    {
+                        try
+                        {
+                            this.GetLoginInfo();
+                        }
+                        catch
+                        {
+                            stateSaver["hadServiceLogonRight"] = true;
+                            throw;
+                        }
+                    }
+                }
+                finally
+                {
+                    stateSaver["Account"] = this.Account;
+                    if (this.Account == ServiceAccount.User)
+                    {
+                        stateSaver["Username"] = this.Username;
+                    }
+                }
+                if (this.Account == ServiceAccount.User)
+                {
+                    IntPtr intPtr = this.OpenSecurityPolicy();
+                    bool flag = true;
+                    try
+                    {
+                        byte[] accountSid = this.GetAccountSid(this.Username);
+                        flag = ServiceProcessInstaller.AccountHasRight(intPtr, accountSid, "SeServiceLogonRight");
+                        if (!flag)
+                        {
+                            ServiceProcessInstaller.GrantAccountRight(intPtr, accountSid, "SeServiceLogonRight");
+                        }
+                    }
+                    finally
+                    {
+                        stateSaver["hadServiceLogonRight"] = flag;
+                        SafeNativeMethods.LsaClose(intPtr);
+                    }
+                }
+            }
+            finally
+            {
+                base.Install(stateSaver);
+            }
+        }
+
+        private IntPtr OpenSecurityPolicy()
+        {
+            GCHandle gCHandle = GCHandle.Alloc(new NativeMethods.LSA_OBJECT_ATTRIBUTES(), GCHandleType.Pinned);
+            try
+            {
+                int num = 0;
+                IntPtr pointerObjectAttributes = gCHandle.AddrOfPinnedObject();
+                IntPtr result = default(IntPtr);
+                num = NativeMethods.LsaOpenPolicy((NativeMethods.LSA_UNICODE_STRING)null, pointerObjectAttributes, 2064, out result);
+                if (num != 0)
+                {
+                    throw new Win32Exception(SafeNativeMethods.LsaNtStatusToWinError(num));
+                }
+                return result;
+            }
+            finally
+            {
+                gCHandle.Free();
+            }
+        }
+
+        private static void RemoveAccountRight(IntPtr policyHandle, byte[] accountSid, string rightName)
+        {
+            NativeMethods.LSA_UNICODE_STRING lSA_UNICODE_STRING = new NativeMethods.LSA_UNICODE_STRING();
+            lSA_UNICODE_STRING.buffer = rightName;
+            NativeMethods.LSA_UNICODE_STRING lSA_UNICODE_STRING2 = lSA_UNICODE_STRING;
+            lSA_UNICODE_STRING2.length = (short)(lSA_UNICODE_STRING2.buffer.Length * 2);
+            NativeMethods.LSA_UNICODE_STRING lSA_UNICODE_STRING3 = lSA_UNICODE_STRING;
+            lSA_UNICODE_STRING3.maximumLength = lSA_UNICODE_STRING3.length;
+            int num = NativeMethods.LsaRemoveAccountRights(policyHandle, accountSid, false, lSA_UNICODE_STRING, 1);
+            if (num == 0)
+            {
+                return;
+            }
+            throw new Win32Exception(SafeNativeMethods.LsaNtStatusToWinError(num));
+        }
+
+        /// <summary>Rolls back service application information written to the registry by the installation procedure. This method is meant to be used by installation tools, which process the appropriate methods automatically.</summary>
+        /// <param name="savedState">An <see cref="T:System.Collections.IDictionary" /> that contains the context information associated with the installation. </param>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="savedState" /> is null.-or- The <paramref name="savedState" /> is corrupted or non-existent. </exception>
+        /// <PermissionSet>
+        ///   <IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode" />
+        /// </PermissionSet>
+        public override void Rollback(IDictionary savedState)
+        {
+            try
+            {
+                if ((ServiceAccount)savedState["Account"] == ServiceAccount.User && !(bool)savedState["hadServiceLogonRight"])
+                {
+                    string accountName = (string)savedState["Username"];
+                    IntPtr intPtr = this.OpenSecurityPolicy();
+                    try
+                    {
+                        byte[] accountSid = this.GetAccountSid(accountName);
+                        ServiceProcessInstaller.RemoveAccountRight(intPtr, accountSid, "SeServiceLogonRight");
+                    }
+                    finally
+                    {
+                        SafeNativeMethods.LsaClose(intPtr);
+                    }
+                }
+            }
+            finally
+            {
+                base.Rollback(savedState);
+            }
+        }
+    }
+}

--- a/src/TopShelf.ServiceInstaller/System.ServiceProcess/System.ServiceProcess.resx
+++ b/src/TopShelf.ServiceInstaller/System.ServiceProcess/System.ServiceProcess.resx
@@ -1,0 +1,427 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InstallSuccessful" xml:space="preserve">
+    <value>Service was installed successfully.</value>
+  </data>
+  <data name="CantInstallOnWin9x" xml:space="preserve">
+    <value>A Windows service cannot be installed on this operating system. It can only be installed on Windows NT, Windows 2000, or later.</value>
+  </data>
+  <data name="ServiceDependency" xml:space="preserve">
+    <value>Service dependency name {1} of service {0} contains invalid characters.</value>
+  </data>
+  <data name="ServiceStartedIncorrectly" xml:space="preserve">
+    <value>Service was not started correctly. Type net start [&lt;ServiceName&gt;] from the command line or use the Control Panel to start the service.</value>
+  </data>
+  <data name="CantControlOnWin9x" xml:space="preserve">
+    <value>Operating system does not support controlling a Windows service. A service can only be controlled on Windows NT, Windows 2000, or later.</value>
+  </data>
+  <data name="ServiceProcessInstallerAccount" xml:space="preserve">
+    <value>Indicates the account type under which the service will run.</value>
+  </data>
+  <data name="InstallFailed" xml:space="preserve">
+    <value>Failed to install service. Service may have been installed already.</value>
+  </data>
+  <data name="ServiceName" xml:space="preserve">
+    <value>Service name {0} contains invalid characters, is empty, or is too long (max length = {1}).</value>
+  </data>
+  <data name="SBAutoLog" xml:space="preserve">
+    <value>Whether the service should automatically write to the event log on common events such as Install and Start.</value>
+  </data>
+  <data name="ServiceControllerDesc" xml:space="preserve">
+    <value>Provides the ability to connect to, query, and manipulate running or stopped Windows services.</value>
+  </data>
+  <data name="ResumeService" xml:space="preserve">
+    <value>Cannot resume {0} service on computer '{1}'.</value>
+  </data>
+  <data name="UserCanceledInstall" xml:space="preserve">
+    <value>User has canceled installation of services in executable {0}.</value>
+  </data>
+  <data name="BadMachineName" xml:space="preserve">
+    <value>MachineName value {0} is invalid.</value>
+  </data>
+  <data name="CommandFailed" xml:space="preserve">
+    <value>Failed to process service command. {0}</value>
+  </data>
+  <data name="InstallService" xml:space="preserve">
+    <value>Install Service : {0}</value>
+  </data>
+  <data name="OpenSC" xml:space="preserve">
+    <value>Cannot open Service Control Manager on computer '{0}'. This operation might require other privileges.</value>
+  </data>
+  <data name="CantStartFromCommandLineTitle" xml:space="preserve">
+    <value>Windows Service Start Failure</value>
+  </data>
+  <data name="ServiceInstallerStartType" xml:space="preserve">
+    <value>Indicates how and when this service is started.</value>
+  </data>
+  <data name="SPDependentServices" xml:space="preserve">
+    <value>The services that depend on this service in order to run.</value>
+  </data>
+  <data name="NoMachineName" xml:space="preserve">
+    <value>MachineName was not set.</value>
+  </data>
+  <data name="ServiceRemoved" xml:space="preserve">
+    <value>Service {0} was successfully removed from the system.</value>
+  </data>
+  <data name="CantStartFromCommandLine" xml:space="preserve">
+    <value>Cannot start service from the command line or a debugger.  A Windows Service must first be installed (using installutil.exe) and then started with the ServerExplorer, Windows Services Administrative tool or the NET START command.</value>
+  </data>
+  <data name="PauseFailed" xml:space="preserve">
+    <value>Failed to pause service. {0}</value>
+  </data>
+  <data name="NotAService" xml:space="preserve">
+    <value>ServiceInstaller cannot install the component because it does not inherit from Service.</value>
+  </data>
+  <data name="PauseService" xml:space="preserve">
+    <value>Cannot pause {0} service on computer '{1}'.</value>
+  </data>
+  <data name="TryToStop" xml:space="preserve">
+    <value>Attempt to stop service {0}.</value>
+  </data>
+  <data name="Timeout" xml:space="preserve">
+    <value>Time out has expired and the operation has not been completed.</value>
+  </data>
+  <data name="NoGivenName" xml:space="preserve">
+    <value>ServiceName and DisplayName have not been set. Either ServiceName or DisplayName is required. </value>
+  </data>
+  <data name="UnattendedCannotPrompt" xml:space="preserve">
+    <value>Username and password were not provided when installing the service located at {0}. Unattended installation does not provide a logon prompt for the username and password during installation.   </value>
+  </data>
+  <data name="CommandSuccessful" xml:space="preserve">
+    <value>Service command was processed successfully.</value>
+  </data>
+  <data name="SPServiceType" xml:space="preserve">
+    <value>The type of this service.</value>
+  </data>
+  <data name="SPServiceName" xml:space="preserve">
+    <value>The short name of the service.</value>
+  </data>
+  <data name="NotInPendingState" xml:space="preserve">
+    <value>UpdatePendingStatus can only be called during the handling of Start, Stop, Pause and Continue commands.</value>
+  </data>
+  <data name="CannotStart" xml:space="preserve">
+    <value>Cannot start service {0} on computer '{1}'.</value>
+  </data>
+  <data name="SPStartType" xml:space="preserve">
+    <value>The start type of the service, e.g. Automatic or Disabled.</value>
+  </data>
+  <data name="StartSuccessful" xml:space="preserve">
+    <value>Service started successfully.</value>
+  </data>
+  <data name="ContinueSuccessful" xml:space="preserve">
+    <value>Service continued successfully.</value>
+  </data>
+  <data name="NoInstaller" xml:space="preserve">
+    <value>Installation failed due to the absence of a ServiceProcessInstaller. The ServiceProcessInstaller must either be the containing installer, or it must be present in the Installers collection on the same installer as the ServiceInstaller.</value>
+  </data>
+  <data name="FailedToUnloadAppDomain" xml:space="preserve">
+    <value>Failed to unload app domain {0}.  The following exception occurred: {1}.</value>
+  </data>
+  <data name="CannotChangeProperties" xml:space="preserve">
+    <value>Cannot change CanStop, CanPauseAndContinue, CanShutdown, CanHandlePowerEvent, or CanHandleSessionChangeEvent property values after the service has been started.</value>
+  </data>
+  <data name="SBServiceName" xml:space="preserve">
+    <value>The name by which the service is identified to the system.</value>
+  </data>
+  <data name="SPCanStop" xml:space="preserve">
+    <value>Whether this service can be stopped.</value>
+  </data>
+  <data name="SPServicesDependedOn" xml:space="preserve">
+    <value>Services that must be started in order for this one to start.</value>
+  </data>
+  <data name="CantRunOnWin9x" xml:space="preserve">
+    <value>Operating system does not support a Windows service. A service can only be run on Windows NT, Windows 2000, or later.</value>
+  </data>
+  <data name="InstallOK" xml:space="preserve">
+    <value>Service {0} has been successfully installed.</value>
+  </data>
+  <data name="ServiceInstallerServicesDependedOn" xml:space="preserve">
+    <value>Indicates the services that must be running in order for this service to run.</value>
+  </data>
+  <data name="ServiceRemoving" xml:space="preserve">
+    <value>Service {0} is being removed from the system...</value>
+  </data>
+  <data name="StartingService" xml:space="preserve">
+    <value>Starting service {0}...</value>
+  </data>
+  <data name="CannotChangeName" xml:space="preserve">
+    <value>Cannot change service name when the service is running.</value>
+  </data>
+  <data name="ServiceInstallerDescription" xml:space="preserve">
+    <value>Indicates the service's description (a brief comment that explains the purpose of the service). </value>
+  </data>
+  <data name="StopService" xml:space="preserve">
+    <value>Cannot stop {0} service on computer '{1}'.</value>
+  </data>
+  <data name="SPDisplayName" xml:space="preserve">
+    <value>The descriptive name of the service.</value>
+  </data>
+  <data name="StopFailed" xml:space="preserve">
+    <value>Failed to stop service. {0}</value>
+  </data>
+  <data name="ShutdownOK" xml:space="preserve">
+    <value>Service has been successfully shut down.</value>
+  </data>
+  <data name="InvalidParameter" xml:space="preserve">
+    <value>Invalid value {1} for parameter {0}.</value>
+  </data>
+  <data name="StartFailed" xml:space="preserve">
+    <value>Service cannot be started. {0}</value>
+  </data>
+  <data name="InstallingService" xml:space="preserve">
+    <value>Installing service {0}...</value>
+  </data>
+  <data name="UninstallSuccessful" xml:space="preserve">
+    <value>Service was uninstalled successfully.</value>
+  </data>
+  <data name="NoDisplayName" xml:space="preserve">
+    <value>Display name could not be retrieved for service {0} on computer '{1}'.</value>
+  </data>
+  <data name="ServiceNameTooLongForNt4" xml:space="preserve">
+    <value>Service name must be 80 characters or less on this operating system.</value>
+  </data>
+  <data name="NoServices" xml:space="preserve">
+    <value>Service has not been supplied. At least one object derived from ServiceBase is required in order to run.</value>
+  </data>
+  <data name="RTL" xml:space="preserve">
+    <value>RTL_False</value>
+  </data>
+  <data name="DisplayNameTooLong" xml:space="preserve">
+    <value>Display name {0} is too long. Display name must be 255 characters or less.</value>
+  </data>
+  <data name="PowerEventOK" xml:space="preserve">
+    <value>PowerEvent handled successfully by the service.</value>
+  </data>
+  <data name="ServiceInstallerDelayedAutoStart" xml:space="preserve">
+    <value>Contains the delayed auto-start setting of service. This setting is ignored unless the service is an auto-start service.</value>
+  </data>
+  <data name="UserName" xml:space="preserve">
+    <value>User Name:</value>
+  </data>
+  <data name="ButtonOK" xml:space="preserve">
+    <value>&amp;OK</value>
+  </data>
+  <data name="SBServiceDescription" xml:space="preserve">
+    <value>The description of the service.</value>
+  </data>
+  <data name="CantRunOnWin9xTitle" xml:space="preserve">
+    <value>Windows Service Error</value>
+  </data>
+  <data name="ServiceUsage" xml:space="preserve">
+    <value>Usage: &lt;ServiceExeName&gt; &lt;Options&gt; 
+ -Install 
+ -InstallLogin [&lt;UserName&gt; &lt;Password&gt;] 
+ -Uninstall</value>
+  </data>
+  <data name="ServiceInstallerServiceName" xml:space="preserve">
+    <value>Indicates the name used by the system to identify this service.</value>
+  </data>
+  <data name="SPCanShutdown" xml:space="preserve">
+    <value>Whether this service can respond to a system shutdown.</value>
+  </data>
+  <data name="Label_SetServiceLogin" xml:space="preserve">
+    <value>Set Service Login</value>
+  </data>
+  <data name="OpenService" xml:space="preserve">
+    <value>Cannot open {0} service on computer '{1}'.</value>
+  </data>
+  <data name="ServiceInstallerDisplayName" xml:space="preserve">
+    <value>Indicates the friendly name that identifies the service to the user.</value>
+  </data>
+  <data name="SPCanPauseAndContinue" xml:space="preserve">
+    <value>Whether this service recognizes the Pause and Continue commands.</value>
+  </data>
+  <data name="ErrorNumber" xml:space="preserve">
+    <value>Windows Error number: {0}.</value>
+  </data>
+  <data name="PauseSuccessful" xml:space="preserve">
+    <value>Service paused successfully.</value>
+  </data>
+  <data name="SPMachineName" xml:space="preserve">
+    <value>The name of the machine on which this service resides.</value>
+  </data>
+  <data name="StopSuccessful" xml:space="preserve">
+    <value>Service stopped successfully.</value>
+  </data>
+  <data name="FileName" xml:space="preserve">
+    <value>Cannot get service file name.</value>
+  </data>
+  <data name="ControlService" xml:space="preserve">
+    <value>Cannot control {0} service on computer '{1}'.</value>
+  </data>
+  <data name="ShutdownFailed" xml:space="preserve">
+    <value>Failed to shut down service. The error that occurred was: {0}.</value>
+  </data>
+  <data name="ArgsCantBeNull" xml:space="preserve">
+    <value>Arguments within the 'args' array passed to Start cannot be null. </value>
+  </data>
+  <data name="Label_MissmatchedPasswords" xml:space="preserve">
+    <value>The passwords do not match.  Re-enter the password.</value>
+  </data>
+  <data name="SessionChangeFailed" xml:space="preserve">
+    <value>Failed to process session change. {0}</value>
+  </data>
+  <data name="ContinueFailed" xml:space="preserve">
+    <value>Failed to continue service. {0}</value>
+  </data>
+  <data name="StartService" xml:space="preserve">
+    <value>Cannot start {0} service on computer '{1}'.</value>
+  </data>
+  <data name="NoService" xml:space="preserve">
+    <value>Service {0} was not found on computer '{1}'.</value>
+  </data>
+  <data name="SPStatus" xml:space="preserve">
+    <value>The status of the service, e.g., Running or Stopped.</value>
+  </data>
+  <data name="HelpText" xml:space="preserve">
+    <value>Options for installing a Service Application:
+/username=name
+    Sets the user account to run the service under. You must also
+    specify the /password= option.
+
+/password=pwd
+    Sets the password for the account to run the service under.
+
+The /username and /password options will be used only if the vendor of
+the service designated it as requiring a user account. If a service was
+so designated, and you do not use the /username and /password options,
+you will be prompted at install time for the account.
+/unattended
+    Unattended install.  Will not prompt for username or password.</value>
+  </data>
+  <data name="CallbackHandler" xml:space="preserve">
+    <value>Cannot register control callback handler for service {0}.</value>
+  </data>
+  <data name="ServiceStartType" xml:space="preserve">
+    <value>Start type {0} is invalid for non-device driver services. </value>
+  </data>
+  <data name="PowerEventFailed" xml:space="preserve">
+    <value>Failed in handling the PowerEvent. The error that occurred was: {0}.</value>
+  </data>
+  <data name="UserPassword" xml:space="preserve">
+    <value>Password:</value>
+  </data>
+  <data name="InstallError" xml:space="preserve">
+    <value>Install Error</value>
+  </data>
+  <data name="UninstallFailed" xml:space="preserve">
+    <value>Failed to uninstall service. Service may be running.</value>
+  </data>
+</root>

--- a/src/TopShelf.ServiceInstaller/TopShelf.ServiceInstaller.csproj
+++ b/src/TopShelf.ServiceInstaller/TopShelf.ServiceInstaller.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\Topshelf.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Update="System.Configuration.Install\System.Configuration.Install.resx">
+      <LogicalName>System.Configuration.Install.resources</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Update="System.ServiceProcess\System.ServiceProcess.resx">
+      <LogicalName>System.ServiceProcess.resources</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+</Project>

--- a/src/Topshelf.Tests/Topshelf.Tests.csproj
+++ b/src/Topshelf.Tests/Topshelf.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Topshelf.sln
+++ b/src/Topshelf.sln
@@ -19,11 +19,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topshelf.Elmah", "Topshelf.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topshelf.Serilog", "Topshelf.Serilog\Topshelf.Serilog.csproj", "{20F2B28C-3AD6-4B1D-9371-15DF77443DA8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.Extensions.Configuration", "Topshelf.Extensions.Configuration\Topshelf.Extensions.Configuration.csproj", "{90662D65-AF44-4278-BCD6-0F671E7DFD81}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topshelf.Extensions.Configuration", "Topshelf.Extensions.Configuration\Topshelf.Extensions.Configuration.csproj", "{90662D65-AF44-4278-BCD6-0F671E7DFD81}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.Extensions.Logging", "Topshelf.Extensions.Logging\Topshelf.Extensions.Logging.csproj", "{FA64A7F9-BB6B-42C7-ACD0-C0A42FD2650E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topshelf.Extensions.Logging", "Topshelf.Extensions.Logging\Topshelf.Extensions.Logging.csproj", "{FA64A7F9-BB6B-42C7-ACD0-C0A42FD2650E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.Extensions.Configuration.Tests", "Topshelf.Extensions.Configuration.Tests\Topshelf.Extensions.Configuration.Tests.csproj", "{98E391A8-3132-4D60-818A-A68A62254068}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topshelf.Extensions.Configuration.Tests", "Topshelf.Extensions.Configuration.Tests\Topshelf.Extensions.Configuration.Tests.csproj", "{98E391A8-3132-4D60-818A-A68A62254068}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TopShelf.ServiceInstaller", "TopShelf.ServiceInstaller\TopShelf.ServiceInstaller.csproj", "{699FB86C-E57F-4750-BE0F-ACDCC3F19364}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -188,6 +190,24 @@ Global
 		{98E391A8-3132-4D60-818A-A68A62254068}.ReleaseUnsigned|Mixed Platforms.Build.0 = Release|Any CPU
 		{98E391A8-3132-4D60-818A-A68A62254068}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
 		{98E391A8-3132-4D60-818A-A68A62254068}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Debug|x86.Build.0 = Debug|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Release|Any CPU.Build.0 = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Release|x86.ActiveCfg = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.Release|x86.Build.0 = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.ReleaseUnsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.ReleaseUnsigned|Any CPU.Build.0 = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.ReleaseUnsigned|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.ReleaseUnsigned|Mixed Platforms.Build.0 = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.ReleaseUnsigned|x86.ActiveCfg = Release|Any CPU
+		{699FB86C-E57F-4750-BE0F-ACDCC3F19364}.ReleaseUnsigned|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Topshelf/Configuration/HostConfigurators/CommandLineParserOptions.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/CommandLineParserOptions.cs
@@ -45,7 +45,6 @@ namespace Topshelf.HostConfigurators
                     select (Option)new StopOption())
                 .Or(from arg in x.Argument("start")
                     select (Option)new StartOption())
-#if !NETCORE
                 .Or(from arg in x.Argument("install")
                     select (Option)new InstallOption())
                 .Or(from arg in x.Argument("uninstall")
@@ -71,7 +70,6 @@ namespace Topshelf.HostConfigurators
                     select (Option)new LocalServiceOption())
                 .Or(from autostart in x.Switch("networkservice")
                     select (Option)new NetworkServiceOption())
-#endif
 );
         }
 

--- a/src/Topshelf/Configuration/HostConfigurators/DependencyHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/DependencyHostConfigurator.cs
@@ -45,9 +45,8 @@ namespace Topshelf.HostConfigurators
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
-#if !NETCORE
             builder.Match<InstallBuilder>(x => x.AddDependency(Name));
-#endif
+
             return builder;
         }
     }

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -21,10 +21,7 @@ namespace Topshelf.HostConfigurators
     using Logging;
     using Options;
     using Runtime;
-#if NETCORE
-    using Runtime.DotNetCore;
-#endif
-    using Runtime.Windows;
+   using Runtime.Windows;
 
 
     public class HostConfiguratorImpl :
@@ -243,11 +240,7 @@ namespace Topshelf.HostConfigurators
 
         static EnvironmentBuilder DefaultEnvironmentBuilderFactory(HostConfigurator configurator)
         {
-#if NETCORE
-            return new DotNetCoreEnvironmentBuilder(configurator);
-#else
             return new WindowsHostEnvironmentBuilder(configurator);
-#endif
-        }
+        }   
     }
 }

--- a/src/Topshelf/Configuration/HostConfigurators/RunAsUserHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/RunAsUserHostConfigurator.cs
@@ -36,9 +36,8 @@ namespace Topshelf.HostConfigurators
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
             
-#if !NETCORE
             builder.Match<InstallBuilder>(x => x.RunAs(Username, Password, ServiceAccount.User));
-#endif
+
             return builder;
         }
 

--- a/src/Topshelf/Configuration/HostConfigurators/RunAsVirtualAccountHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/RunAsVirtualAccountHostConfigurator.cs
@@ -31,10 +31,8 @@ namespace Topshelf.HostConfigurators
             if (builder == null)
                 throw new ArgumentNullException("builder");
 
-#if !NETCORE
             builder.Match<InstallBuilder>(x => x.RunAs("NT SERVICE\\" + x.Settings.ServiceName, "", ServiceAccount.User));
-#endif
-            
+
             return builder;
         }
 

--- a/src/Topshelf/Configuration/HostConfigurators/ServiceRecoveryHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/ServiceRecoveryHostConfigurator.cs
@@ -47,9 +47,7 @@ namespace Topshelf.HostConfigurators
 
             _settings = builder.Settings;
 
-#if !NETCORE
             builder.Match<InstallBuilder>(x => x.AfterInstall(ConfigureServiceRecovery));
-#endif
 
             return builder;
         }
@@ -102,12 +100,10 @@ namespace Topshelf.HostConfigurators
             Options.RecoverOnCrashOnly = true;
         }
 
-#if !NETCORE
         void ConfigureServiceRecovery(InstallHostSettings installSettings)
         {
             var controller = new WindowsServiceRecoveryController();
             controller.SetServiceRecoveryOptions(_settings, _options);
         }
-#endif
     }
 }

--- a/src/Topshelf/Configuration/HostConfigurators/StartModeHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/StartModeHostConfigurator.cs
@@ -40,10 +40,8 @@ namespace Topshelf.HostConfigurators
             if (builder == null)
                 throw new ArgumentNullException("builder");
 
-#if !NETCORE
             builder.Match<InstallBuilder>(x => x.SetStartMode(StartMode));
-#endif
-            
+
             return builder;
         }
     }

--- a/src/Topshelf/Configuration/RunAsExtensions.cs
+++ b/src/Topshelf/Configuration/RunAsExtensions.cs
@@ -47,11 +47,9 @@ namespace Topshelf
             if (configurator == null)
                 throw new ArgumentNullException(nameof(configurator));
 
-#if !NETCORE
             var runAsConfigurator = new RunAsServiceAccountHostConfigurator(ServiceAccount.User);
 
             configurator.AddConfigurator(runAsConfigurator);
-#endif
 
             return configurator;
         }
@@ -61,11 +59,9 @@ namespace Topshelf
             if (configurator == null)
                 throw new ArgumentNullException(nameof(configurator));
 
-#if !NETCORE
             var runAsConfigurator = new RunAsServiceAccountHostConfigurator(ServiceAccount.NetworkService);
 
             configurator.AddConfigurator(runAsConfigurator);
-#endif
 
             return configurator;
         }
@@ -75,11 +71,9 @@ namespace Topshelf
             if (configurator == null)
                 throw new ArgumentNullException(nameof(configurator));
 
-#if !NETCORE
             var runAsConfigurator = new RunAsServiceAccountHostConfigurator(ServiceAccount.LocalSystem);
 
             configurator.AddConfigurator(runAsConfigurator);
-#endif
 
             return configurator;
         }
@@ -89,11 +83,9 @@ namespace Topshelf
             if (configurator == null)
                 throw new ArgumentNullException(nameof(configurator));
 
-#if !NETCORE
             var runAsConfigurator = new RunAsServiceAccountHostConfigurator(ServiceAccount.LocalService);
 
             configurator.AddConfigurator(runAsConfigurator);
-#endif
 
             return configurator;
         }

--- a/src/Topshelf/Runtime/DotNetCore/DotNetCoreEnvironmentBuilder.cs
+++ b/src/Topshelf/Runtime/DotNetCore/DotNetCoreEnvironmentBuilder.cs
@@ -10,6 +10,8 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
+
+#if NETCORE
 namespace Topshelf.Runtime.DotNetCore
 {
     using Builders;
@@ -31,3 +33,4 @@ namespace Topshelf.Runtime.DotNetCore
         }
     }
 }
+#endif

--- a/src/Topshelf/Runtime/HostEnvironment.cs
+++ b/src/Topshelf/Runtime/HostEnvironment.cs
@@ -60,7 +60,6 @@ namespace Topshelf.Runtime
         /// <param name="stopTimeOut">Waits for the service to reach the stopeed status in the specified time.</param>
         void StopService(string serviceName, TimeSpan stopTimeOut);
 
-#if !NETCORE
         /// <summary>
         /// Install the service using the settings provided
         /// </summary>
@@ -70,7 +69,6 @@ namespace Topshelf.Runtime
         /// <param name="beforeRollback"> </param>
         /// <param name="afterRollback"> </param>
         void InstallService(InstallHostSettings settings, Action<InstallHostSettings> beforeInstall, Action afterInstall, Action beforeRollback, Action afterRollback);
-#endif
         
         /// <summary>
         /// Uninstall the service using the settings provided

--- a/src/Topshelf/Runtime/Windows/HostServiceInstaller.cs
+++ b/src/Topshelf/Runtime/Windows/HostServiceInstaller.cs
@@ -156,7 +156,13 @@ namespace Topshelf.Runtime.Windows
             if (assembly == null)
                 throw new TopshelfException("Assembly.GetEntryAssembly() is null for some reason.");
 
-            string path = string.Format("/assemblypath={0}", assembly.Location);
+#if NETCORE
+            // Must run off Self Contained Deployment
+            string path = $"/assemblypath={assembly.Location.Replace(".dll", ".exe")}";
+#else
+            string path = $"/assemblypath={assembly.Location}";
+
+#endif
             string[] commandLine = { path };
 
             var context = new InstallContext(null, commandLine);

--- a/src/Topshelf/Topshelf.csproj
+++ b/src/Topshelf/Topshelf.csproj
@@ -17,29 +17,11 @@
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Compile Remove="Runtime/DotNetCore/DotNetCoreHostEnvironment.cs" />
-    <Compile Remove="Runtime/DotNetCore/DotNetCoreEnvironmentBuilder.cs" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.0" />
+    <ProjectReference Include="..\TopShelf.ServiceInstaller\TopShelf.ServiceInstaller.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <Compile Remove="Configuration/Builders/InstallBuilder.cs" />
-    <Compile Remove="Configuration/HostConfigurators/InstallHostConfiguratorAction.cs" />
-    <Compile Remove="Configuration/HostConfigurators/SudoConfigurator.cs" />
-    <Compile Remove="Configuration/HostConfigurators/RunAsServiceAccountHostConfigurator.cs" />
-    <Compile Remove="Configuration/Options/InstallOption.cs" />
-    <Compile Remove="Configuration/Options/SudoOption.cs" />
-    <Compile Remove="Configuration/Credentials.cs" />
-    <Compile Remove="Configuration/InstallHostConfiguratorExtensions.cs" />
-    <Compile Remove="Hosts/InstallHost.cs" />
-    <Compile Remove="Runtime/Windows/HostInstaller.cs" />
-    <Compile Remove="Runtime/Windows/HostServiceInstaller.cs" />
-    <Compile Remove="Runtime/Windows/WindowsHostEnvironment.cs" />
-    <Compile Remove="Runtime/Windows/WindowsHostEnvironmentBuilder.cs" />
-    <Compile Remove="Runtime/InstallHostSettings.cs" />
-  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="HelpText.txt" />
   </ItemGroup>


### PR DESCRIPTION
Windows compatibility packs for .NET Core 2.1 contains most, but not all, the dependencies to support installing as a windows service.

The key parts missing is the service installer and the native wrappers around registering services.

I have created an additional library that .NET Core version of TopShelf has as a dependency - TopShelf.ServiceInstaller, ported from the full framework from System.Configuration.Install and System.ServiceProcess.  

This allows "source compatibility" between full framework and .NET Core compiles of TopShelf.