### PR TITLE
Service recovery fixed - 4th "no action" action removed #404

### DIFF
--- a/src/Topshelf/Runtime/Windows/ServiceRecoveryOptions.cs
+++ b/src/Topshelf/Runtime/Windows/ServiceRecoveryOptions.cs
@@ -31,6 +31,12 @@ namespace Topshelf.Runtime.Windows
 
         public void AddAction(ServiceRecoveryAction serviceRecoveryAction)
         {
+            if (_actions.Count == 3)
+            {
+                throw new TopshelfException("Recovery action can not be added. " +
+                                            "Windows recovery does not support more than 3 actions");
+            }
+
             _actions.Add(serviceRecoveryAction);
         }
     }

--- a/src/Topshelf/Runtime/Windows/WindowsServiceRecoveryController.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceRecoveryController.cs
@@ -57,12 +57,6 @@ namespace Topshelf.Runtime.Windows
                     nextAction = (IntPtr)(nextAction.ToInt64() + actionSize);
                 }
 
-                var finalAction = new NativeMethods.SC_ACTION();
-                finalAction.Type = (int)NativeMethods.SC_ACTION_TYPE.None;
-                finalAction.Delay = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
-
-                Marshal.StructureToPtr(finalAction, nextAction, false);
-
                 string rebootMessage = options.Actions.Where(x => x.GetType() == typeof(RestartSystemRecoveryAction))
                                            .OfType<RestartSystemRecoveryAction>().Select(x => x.RestartMessage).
                                            FirstOrDefault() ?? "";
@@ -77,7 +71,7 @@ namespace Topshelf.Runtime.Windows
                     (int)TimeSpan.FromDays(options.ResetPeriod).TotalSeconds;
                 failureActions.lpRebootMsg = rebootMessage;
                 failureActions.lpCommand = runProgramCommand;
-                failureActions.cActions = actions.Count + 1;
+                failureActions.cActions = actions.Count;
                 failureActions.actions = lpsaActions;
 
                 lpInfo = Marshal.AllocHGlobal(Marshal.SizeOf(failureActions));


### PR DESCRIPTION
Fixes #404

Pr was tested manually.
Now the configuration like this:
```C#
HostFactory.New(x =>
{
    x.EnableServiceRecovery(r =>
    {
        r.RestartService(0);
        r.RestartService(0);
        r.RestartService(0);
        //number of days until the error count resets
        r.SetResetPeriod(1);
    });
});
```

Works as Windows understands it:
First failure - restart
Second failure - restart
**Subsequent** failures - restart

Failure counter will be reset after 1 day, which means that during the first failure, the first action kicks in.

Ps.
If someone tries to register more than 3(Windows does not understand more than 3) actions, it will throw TopshelException.
