### PR TITLE
Windows error code compliant #461

### DIFF
--- a/src/Topshelf.Tests/BeforeStart_Specs.cs
+++ b/src/Topshelf.Tests/BeforeStart_Specs.cs
@@ -35,7 +35,7 @@ namespace Topshelf.Tests
                 });
 
             Assert.IsFalse(started);
-            Assert.AreEqual(TopshelfExitCode.StartServiceFailed, exitCode);
+            Assert.AreEqual(TopshelfExitCode.ServiceControlRequestFailed, exitCode);
         }
 
 

--- a/src/Topshelf.Tests/ExceptionHandler_Specs.cs
+++ b/src/Topshelf.Tests/ExceptionHandler_Specs.cs
@@ -50,7 +50,7 @@ namespace Topshelf.Tests
 
             Assert.IsTrue(sawExceptionInStart);
             Assert.IsFalse(sawExceptionInStop);
-            Assert.AreEqual(TopshelfExitCode.StartServiceFailed, exitCode);
+            Assert.AreEqual(TopshelfExitCode.ServiceControlRequestFailed, exitCode);
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace Topshelf.Tests
 
             Assert.IsFalse(sawExceptionInStart);
             Assert.IsTrue(sawExceptionInStop);
-            Assert.AreEqual(TopshelfExitCode.StopServiceFailed, exitCode);
+            Assert.AreEqual(TopshelfExitCode.ServiceControlRequestFailed, exitCode);
         }
 
         [Test]
@@ -115,7 +115,7 @@ namespace Topshelf.Tests
                 x.Service(settings => new ExceptionThrowingService(true, false));
             });
 
-            Assert.AreEqual(TopshelfExitCode.StartServiceFailed, exitCode);
+            Assert.AreEqual(TopshelfExitCode.ServiceControlRequestFailed, exitCode);
 
             exitCode = HostFactory.Run(x =>
             {
@@ -124,7 +124,7 @@ namespace Topshelf.Tests
                 x.Service(settings => new ExceptionThrowingService(false, true));
             });
 
-            Assert.AreEqual(TopshelfExitCode.StopServiceFailed, exitCode);
+            Assert.AreEqual(TopshelfExitCode.ServiceControlRequestFailed, exitCode);
 
         }
 

--- a/src/Topshelf/Hosts/CommandHost.cs
+++ b/src/Topshelf/Hosts/CommandHost.cs
@@ -58,7 +58,7 @@ namespace Topshelf.Hosts
             catch (Exception ex)
             {
                 _log.Error("The command could not be sent to the service.", ex);
-                return TopshelfExitCode.SendCommandFailed;
+                return TopshelfExitCode.ServiceControlRequestFailed;
             }
         }
     }

--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -159,7 +159,7 @@ namespace Topshelf.Hosts
 
             if (e.IsTerminating)
             {
-                _exitCode = TopshelfExitCode.UnhandledServiceException;
+                _exitCode = TopshelfExitCode.AbnormalExit;
                 _exit.Set();
 
                 // it isn't likely that a TPL thread should land here, but if it does let's no block it
@@ -195,7 +195,7 @@ namespace Topshelf.Hosts
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Error("The service did not shut down gracefully", ex);
-                _exitCode = TopshelfExitCode.StopServiceFailed;
+                _exitCode = TopshelfExitCode.ServiceControlRequestFailed;
             }
             finally
             {

--- a/src/Topshelf/Hosts/StartHost.cs
+++ b/src/Topshelf/Hosts/StartHost.cs
@@ -67,7 +67,7 @@ namespace Topshelf.Hosts
             catch (Exception ex)
             {
                 _log.Error("The service failed to start.", ex);
-                return TopshelfExitCode.StartServiceFailed;
+                return TopshelfExitCode.ServiceControlRequestFailed;
             }
         }
     }

--- a/src/Topshelf/Hosts/StopHost.cs
+++ b/src/Topshelf/Hosts/StopHost.cs
@@ -65,7 +65,7 @@ namespace Topshelf.Hosts
             catch (Exception ex)
             {
                 _log.Error("The service failed to stop.", ex);
-                return TopshelfExitCode.StopServiceFailed;
+                return TopshelfExitCode.ServiceControlRequestFailed;
             }
         }
     }

--- a/src/Topshelf/Hosts/TestHost.cs
+++ b/src/Topshelf/Hosts/TestHost.cs
@@ -41,7 +41,7 @@ namespace Topshelf.Hosts
             var exitCode = TopshelfExitCode.AbnormalExit;
             try
             {
-                exitCode = TopshelfExitCode.StartServiceFailed;
+                exitCode = TopshelfExitCode.ServiceControlRequestFailed;
 
                 _log.InfoFormat("The {0} service is being started.", _settings.ServiceName);
                 _serviceHandle.Start(this);
@@ -49,7 +49,7 @@ namespace Topshelf.Hosts
 
                 Thread.Sleep(100);
 
-                exitCode = TopshelfExitCode.StopServiceFailed;
+                exitCode = TopshelfExitCode.ServiceControlRequestFailed;
 
                 _log.InfoFormat("The {0} service is being stopped.", _settings.ServiceName);
                 _serviceHandle.Stop(this);

--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -147,7 +147,7 @@ namespace Topshelf.Runtime.Windows
 
                 _log.Fatal("The service did not start successfully", ex);
 
-                ExitCode = (int) TopshelfExitCode.StartServiceFailed;
+                ExitCode = (int) TopshelfExitCode.ServiceControlRequestFailed;
                 throw;
             }
         }
@@ -168,13 +168,13 @@ namespace Topshelf.Runtime.Windows
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not shut down gracefully", ex);
-                ExitCode = (int) TopshelfExitCode.StopServiceFailed;
+                ExitCode = (int) TopshelfExitCode.ServiceControlRequestFailed;
                 throw;
             }
 
             if (_unhandledException != null)
             {
-                ExitCode = (int) TopshelfExitCode.UnhandledServiceException;
+                ExitCode = (int) TopshelfExitCode.AbnormalExit;
                 _log.Info("[Topshelf] Unhandled exception detected, rethrowing to cause application to restart.");
                 throw new InvalidOperationException("An unhandled exception was detected", _unhandledException);
             }
@@ -235,7 +235,7 @@ namespace Topshelf.Runtime.Windows
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did not shut down gracefully", ex);
-                ExitCode = (int) TopshelfExitCode.StopServiceFailed;
+                ExitCode = (int) TopshelfExitCode.ServiceControlRequestFailed;
                 throw;
             }
         }
@@ -257,7 +257,7 @@ namespace Topshelf.Runtime.Windows
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The did not handle Service session change correctly", ex);
-                ExitCode = (int) TopshelfExitCode.StopServiceFailed;
+                ExitCode = (int) TopshelfExitCode.ServiceControlRequestFailed;
                 throw;
             }
         }
@@ -281,7 +281,7 @@ namespace Topshelf.Runtime.Windows
                 _settings.ExceptionCallback?.Invoke(ex);
 
                 _log.Fatal("The service did handle the Power event correctly", ex);
-                ExitCode = (int) TopshelfExitCode.StopServiceFailed;
+                ExitCode = (int) TopshelfExitCode.ServiceControlRequestFailed;
                 throw;
             }
         }
@@ -329,7 +329,7 @@ namespace Topshelf.Runtime.Windows
 //                return;
 //          This needs to be a configuration option to avoid breaking compatibility
 
-            ExitCode = (int) TopshelfExitCode.UnhandledServiceException;
+            ExitCode = (int) TopshelfExitCode.AbnormalExit;
             _unhandledException = (Exception) e.ExceptionObject;
 
             Stop();

--- a/src/Topshelf/Topshelf.csproj
+++ b/src/Topshelf/Topshelf.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <ProjectReference Include="..\TopShelf.ServiceInstaller\TopShelf.ServiceInstaller.csproj" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.1"/>
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="HelpText.txt" />

--- a/src/Topshelf/TopshelfExitCode.cs
+++ b/src/Topshelf/TopshelfExitCode.cs
@@ -12,19 +12,37 @@
 // specific language governing permissions and limitations under the License.
 namespace Topshelf
 {
-    public enum TopshelfExitCode
+    public struct TopshelfExitCode
     {
-        Ok = 0,
-        AbnormalExit = 1,
-        SudoRequired = 2,
-        ServiceAlreadyInstalled = 3,
-        ServiceNotInstalled = 4,
-        StartServiceFailed = 5,
-        StopServiceFailed = 6,
-        ServiceAlreadyRunning = 7,
-        UnhandledServiceException = 8,
-        ServiceNotRunning = 9,
-        SendCommandFailed = 10,
-        NotRunningOnWindows = 11,
+        private readonly int _exitCode;
+
+        public TopshelfExitCode(int exitCode)
+        {
+            _exitCode = exitCode;
+        }
+        
+        public static explicit operator int(TopshelfExitCode topshelfExitCode)
+        {
+            return topshelfExitCode._exitCode;
+        }
+
+        // windows service exit code compliant 
+        // https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes
+        public static TopshelfExitCode Ok { get; } = new TopshelfExitCode(0);
+        public static TopshelfExitCode ServiceAlreadyInstalled { get; } = new TopshelfExitCode(1242);
+        public static TopshelfExitCode ServiceNotInstalled { get; } = new TopshelfExitCode(1243);
+        public static TopshelfExitCode ServiceAlreadyRunning { get; } = new TopshelfExitCode(1056);
+        public static TopshelfExitCode ServiceNotRunning { get; } = new TopshelfExitCode(1062);
+        public static TopshelfExitCode ServiceControlRequestFailed { get; } = new TopshelfExitCode(1064);
+        public static TopshelfExitCode AbnormalExit { get; } = new TopshelfExitCode(1067);
+        
+        // non-compliant
+        public static TopshelfExitCode SudoRequired { get; } = new TopshelfExitCode(2);
+        public static TopshelfExitCode NotRunningOnWindows { get; } = new TopshelfExitCode(11);
+
+        public override string ToString()
+        {
+            return $"Exit code: {_exitCode}";
+        }
     }
 }


### PR DESCRIPTION
Closes #461 

**Description**
---
1. Most of the exit codes are aligned with [Windows Error Codes](https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes)
1. Some of the exit codes were combined or replaced:
    - (StartServiceFailed = 5, StopServiceFailed = 6,  SendCommandFailed = 10) replaced with  ServiceControlRequestFailed(1064)
    - (UnhandledServiceException = 8) replaced with  AbnormalExit(1067)
1. TopshelfExitCode enum changed to struct - some people might want to return other exit codes rather than the one we listed in the enum. For instance [here](https://github.com/Topshelf/Topshelf/blob/1732d3d8773a8b813784b6f86aacb7ed8e098491/src/SampleTopshelfService/SampleService.cs#L59):  `hostControl.Stop(new TopshelfExitCode(1045));`


 P.s. if Topshelf is ever going to be used on linux with its own service/daemon tooling where the exit code will be different from the windows ones, then it's really easy to add the alternative mapping.
