### PR TITLE
ExitCode cast fix #477

### DIFF
--- a/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs
@@ -77,7 +77,12 @@ namespace Topshelf.Runtime.Windows
 
             Run(this);
 
-            return (TopshelfExitCode) Enum.ToObject(typeof(TopshelfExitCode), ExitCode);
+            // this error code does not matter when running as a windows service
+            // the actual exit code is taken from the ServiceBase.ExitCode
+            // Windows service tooling already sees the service as stopped here -
+            // once ServiceBase.OnStop method exits, but the process is not yet finished here.
+            // even if we put Thread.Sleep(600000) the process will be killed after some timeout
+            return new TopshelfExitCode(ExitCode);
         }
 
         void HostControl.RequestAdditionalTime(TimeSpan timeRemaining)


### PR DESCRIPTION
Fixes #477
Follow up for #475

This bug was due to 2 reasons:
1. There is no easy way to write unit test for the WindowsServiceHost class, so I did not do it with the last commit. I tried it manually and there was no cast issue for me. Explained in point 2.
2. It appears that when running as a windows service the actual exit code is taken from the ServiceBase.Exit right after `ServiceBase.OnStop` method exits. Even though process is still running, the exit code which is returned from Main method does not matter anymore. See comment inline.
