### PR TITLE
Missing setter: Unhandled exception handler should be removed from Topshelf #476

### DIFF
--- a/src/Topshelf.Extensions.Configuration.Tests/Configuration_Specs.cs
+++ b/src/Topshelf.Extensions.Configuration.Tests/Configuration_Specs.cs
@@ -531,6 +531,8 @@ namespace Topshelf.Extensions.Configuration.Tests
 
             public UnhandledExceptionPolicyCode UnhandledExceptionPolicy => throw new NotImplementedException();
 
+            UnhandledExceptionPolicyCode HostConfigurator.UnhandledExceptionPolicy { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
             public void AddCommandLineDefinition(string name, Action<string> callback)
             {
                 throw new NotImplementedException();

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
@@ -127,10 +127,10 @@ namespace Topshelf.HostConfigurators
         /// <param name="callback">The action to run when an exception occurs.</param>
         void OnException(Action<Exception> callback);
 
-      /// <summary>
-      /// The policy that will be used when Topself detects an UnhandledException in the
-      /// application. The default policy is to log an error and to stop the service.
-      /// </summary>
-      UnhandledExceptionPolicyCode UnhandledExceptionPolicy { get; }
+        /// <summary>
+        /// The policy that will be used when Topself detects an UnhandledException in the
+        /// application. The default policy is to log an error and to stop the service.
+        /// </summary>
+        UnhandledExceptionPolicyCode UnhandledExceptionPolicy { get; set; }
   }
 }


### PR DESCRIPTION
@phatboyg sorry, but I missed the setter in HostConfigurator. So there is actually no way of setting the UnhandledExceptionPolicy.