### PR TITLE
Allow to set "no action" as recovery action #493

### DIFF
--- a/src/Topshelf/Configuration/HostConfigurators/ServiceRecoveryHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/ServiceRecoveryHostConfigurator.cs
@@ -134,6 +134,17 @@ namespace Topshelf.HostConfigurators
         }
 
         /// <summary>
+        /// Adds a take no action recovery action.
+        /// </summary>
+        /// <returns>The service recovery configurator.</returns>
+        public ServiceRecoveryConfigurator TakeNoAction()
+        {
+            Options.AddAction(new TakeNoActionAction());
+
+            return this;
+        }
+
+        /// <summary>
         /// Sets the recovery reset period in days.
         /// </summary>
         /// <param name="days">The reset period in days.</param>

--- a/src/Topshelf/Configuration/ServiceRecoveryConfigurator.cs
+++ b/src/Topshelf/Configuration/ServiceRecoveryConfigurator.cs
@@ -64,6 +64,12 @@ namespace Topshelf
         ServiceRecoveryConfigurator RunProgram(int delayInMinutes, string command);
 
         /// <summary>
+        ///   Take no action
+        /// </summary>
+        /// <returns>The service recovery configurator.</returns>
+        ServiceRecoveryConfigurator TakeNoAction();
+
+        /// <summary>
         ///   Specifies the reset period for the restart options
         /// </summary>
         /// <param name="days">The reset period in days.</param>

--- a/src/Topshelf/Runtime/Windows/TakeNoActionAction.cs
+++ b/src/Topshelf/Runtime/Windows/TakeNoActionAction.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2007-2012 Chris Patterson, Dru Sellers, Travis Smith, et. al.
+//  
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Topshelf.Runtime.Windows
+{
+    using System;
+
+    /// <summary>
+    /// Represents a take no action recovery action.
+    /// </summary>
+    public class TakeNoActionAction :
+        ServiceRecoveryAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TakeNoActionAction"/> class.
+        /// </summary>
+        public TakeNoActionAction()
+            : base(TimeSpan.Zero)
+        {
+        }
+
+        /// <summary>
+        /// Gets the service recovery configuration action.
+        /// </summary>
+        /// <returns>A <see cref="NativeMethods.SC_ACTION"/> representing the take no action service recovery configuration action.</returns>
+        public override NativeMethods.SC_ACTION GetAction()
+        {
+            return new NativeMethods.SC_ACTION
+            {
+                Delay = Delay,
+                Type = (int)NativeMethods.SC_ACTION_TYPE.None
+            };
+        }
+    }
+}


### PR DESCRIPTION
This extension of the ServiceRecoveryConfigurator allows to set a "no action" as recovery action.