### PR TITLE
 Pass installSettings parameter to SetServiceRecoveryOptions

### DIFF
--- a/src/Topshelf/Configuration/HostConfigurators/ServiceRecoveryHostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/ServiceRecoveryHostConfigurator.cs
@@ -167,7 +167,7 @@ namespace Topshelf.HostConfigurators
         void ConfigureServiceRecovery(InstallHostSettings installSettings)
         {
             var controller = new WindowsServiceRecoveryController();
-            controller.SetServiceRecoveryOptions(_settings, _options);
+            controller.SetServiceRecoveryOptions(installSettings, _options);
         }
     }
 }


### PR DESCRIPTION
I was having issues trying to get the Topshelf.Squirrel.Updater package to work properly, but I kept getting exceptions from SetServiceRecoveryOptions where the service name did not match.
When used with Topshelf.Squirrel.Updater the base builder settings in _settings were passing the wrong service name. The installSettings parameter had the versioned service name. After making this change, the updater was able to run through without failing.