### PR TITLE
ExceptionCallback can be null #511

### DIFF
--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -218,7 +218,7 @@ namespace Topshelf.HostConfigurators
             //Intercept exceptions from serviceBuilder, TopShelf handling is in HostFactory
             catch (Exception ex)
             {
-                builder.Settings?.ExceptionCallback(ex);
+                builder.Settings?.ExceptionCallback?.Invoke(ex);
                 throw;
             }
         }


### PR DESCRIPTION
ExceptionCallback can be null and causes `Object reference was not set` exception to be thrown. Original exception is hidden in such case. It is described in the issue #511 