### PR TITLE
Add function to enable power event handler

### DIFF
--- a/src/Topshelf.Extensions.Configuration.Tests/Configuration_Specs.cs
+++ b/src/Topshelf.Extensions.Configuration.Tests/Configuration_Specs.cs
@@ -568,7 +568,7 @@ namespace Topshelf.Extensions.Configuration.Tests
                 throw new NotImplementedException();
             }
 
-            public void EnablePowerChanged()
+            public void EnablePowerEvents()
             {
                 throw new NotImplementedException();
             }

--- a/src/Topshelf.Extensions.Configuration.Tests/Configuration_Specs.cs
+++ b/src/Topshelf.Extensions.Configuration.Tests/Configuration_Specs.cs
@@ -568,6 +568,11 @@ namespace Topshelf.Extensions.Configuration.Tests
                 throw new NotImplementedException();
             }
 
+            public void EnablePowerChanged()
+            {
+                throw new NotImplementedException();
+            }
+
             public void EnableShutdown()
             {
                 throw new NotImplementedException();

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
@@ -64,14 +64,14 @@ namespace Topshelf.HostConfigurators
         void EnableShutdown();
 
         /// <summary>
-        /// Enabled support for the session changed event
+        /// Enables support for the session changed event
         /// </summary>
         void EnableSessionChanged();
 
         /// <summary>
-        /// Enabled support for power events (signaled by the host OS)
+        /// Enables support for power events (signaled by the host OS)
         /// </summary>
-        void EnablePowerChanged();
+        void EnablePowerEvents();
 
         /// <summary>
         ///   Specifies the builder factory to use when the service is invoked

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
@@ -69,6 +69,11 @@ namespace Topshelf.HostConfigurators
         void EnableSessionChanged();
 
         /// <summary>
+        /// Enabled support for power events (signaled by the host OS)
+        /// </summary>
+        void EnablePowerChanged();
+
+        /// <summary>
         ///   Specifies the builder factory to use when the service is invoked
         /// </summary>
         /// <param name="hostBuilderFactory"> </param>

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -131,7 +131,7 @@ namespace Topshelf.HostConfigurators
             _settings.CanSessionChanged = true;
         }
 
-        public void EnablePowerChanged()
+        public void EnablePowerEvents()
         {
             _settings.CanHandlePowerEvent = true;
         }

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -131,6 +131,11 @@ namespace Topshelf.HostConfigurators
             _settings.CanSessionChanged = true;
         }
 
+        public void EnablePowerChanged()
+        {
+            _settings.CanHandlePowerEvent = true;
+        }
+
         public void UseHostBuilder(HostBuilderFactory hostBuilderFactory)
         {
             _hostBuilderFactory = hostBuilderFactory;


### PR DESCRIPTION
I suspect this was overlooked as `CanHandlePowerEvent` was never being set to `true` anywhere in the codebase so the service event handler was never being setup under the covers.

Should resolve #384 and #170 

If I'm mistaken and this was intentional please let me know.