### PR TITLE
Stop detached threads from preventing service to stop

### DIFF
--- a/doc/source/configuration/quickstart.rst
+++ b/doc/source/configuration/quickstart.rst
@@ -39,7 +39,7 @@ Topshelf.
             });                                                             //10
 
             var exitCode = (int) Convert.ChangeType(rc, rc.GetTypeCode());  //11
-            Environment.ExitCode = exitCode;
+            Environment.Exit(exitCode);
         }
     }
 


### PR DESCRIPTION
If you're using third party libraries in a Windows Service, you don't always have control over all running threads. When stopping a service this can result in delays or timeouts, preventing the service from actually stopping.

When explicitly calling `Environment.Exit(exitCode)`, detached (or unmanaged) threads started by the service or one of its dependencies are also aborted, causing a clean shutdown of the Windows Service.