### PR TITLE
Adds support for allowing Ctrl+Break to be handled gracefully.

### DIFF
--- a/src/Topshelf.Extensions.Configuration.Tests/Configuration_Specs.cs
+++ b/src/Topshelf.Extensions.Configuration.Tests/Configuration_Specs.cs
@@ -573,6 +573,11 @@ namespace Topshelf.Extensions.Configuration.Tests
                 throw new NotImplementedException();
             }
 
+            public void EnableHandleCtrlBreak()
+            {
+                throw new NotImplementedException();
+            }
+
             public void EnableShutdown()
             {
                 throw new NotImplementedException();

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfigurator.cs
@@ -74,6 +74,11 @@ namespace Topshelf.HostConfigurators
         void EnablePowerEvents();
 
         /// <summary>
+        /// Enables support for gracefully handling Ctrl+Break signals
+        /// </summary>
+        void EnableHandleCtrlBreak();
+
+        /// <summary>
         ///   Specifies the builder factory to use when the service is invoked
         /// </summary>
         /// <param name="hostBuilderFactory"> </param>

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -136,6 +136,11 @@ namespace Topshelf.HostConfigurators
             _settings.CanHandlePowerEvent = true;
         }
 
+        public void EnableHandleCtrlBreak()
+        {
+            _settings.CanHandleCtrlBreak = true;
+        }
+
         public void UseHostBuilder(HostBuilderFactory hostBuilderFactory)
         {
             _hostBuilderFactory = hostBuilderFactory;

--- a/src/Topshelf/Hosts/ConsoleRunHost.cs
+++ b/src/Topshelf/Hosts/ConsoleRunHost.cs
@@ -230,10 +230,13 @@ namespace Topshelf.Hosts
 
         void HandleCancelKeyPress(object sender, ConsoleCancelEventArgs consoleCancelEventArgs)
         {
-            if (consoleCancelEventArgs.SpecialKey == ConsoleSpecialKey.ControlBreak)
+            if (!_settings.CanHandleCtrlBreak)
             {
-                _log.Error("Control+Break detected, terminating service (not cleanly, use Control+C to exit cleanly)");
-                return;
+                if (consoleCancelEventArgs.SpecialKey == ConsoleSpecialKey.ControlBreak)
+                {
+                    _log.Error("Control+Break detected, terminating service (not cleanly, use Control+C to exit cleanly)");
+                    return;
+                }
             }
 
             consoleCancelEventArgs.Cancel = true;
@@ -241,7 +244,7 @@ namespace Topshelf.Hosts
             if (_hasCancelled)
                 return;
 
-            _log.Info("Control+C detected, attempting to stop service.");
+            _log.InfoFormat("Control+{0} detected, attempting to stop service.", consoleCancelEventArgs.SpecialKey == ConsoleSpecialKey.ControlBreak ? "Break" : "C");
             if (_serviceHandle.Stop(this))
             {
                 _hasCancelled = true;

--- a/src/Topshelf/Hosts/InstallHost.cs
+++ b/src/Topshelf/Hosts/InstallHost.cs
@@ -222,6 +222,11 @@ namespace Topshelf.Hosts
             {
               get { return _settings.UnhandledExceptionPolicy; }
             }
+
+            public bool CanHandleCtrlBreak
+            {
+                get { return _settings.CanHandleCtrlBreak; }
+            }
         }
     }
 }

--- a/src/Topshelf/Runtime/HostSettings.cs
+++ b/src/Topshelf/Runtime/HostSettings.cs
@@ -86,5 +86,10 @@ namespace Topshelf.Runtime
         /// application. The default policy is to log an error and to stop the service.
         /// </summary>
         UnhandledExceptionPolicyCode UnhandledExceptionPolicy { get; }
+
+        /// <summary>
+        /// True if the service handles Ctrl+Break gracefully
+        /// </summary>
+        bool CanHandleCtrlBreak { get; }
     }
 }

--- a/src/Topshelf/Runtime/Windows/WindowsHostSettings.cs
+++ b/src/Topshelf/Runtime/Windows/WindowsHostSettings.cs
@@ -111,5 +111,7 @@ namespace Topshelf.Runtime.Windows
         public Action<Exception> ExceptionCallback { get; set; }
 
         public UnhandledExceptionPolicyCode UnhandledExceptionPolicy { get; set; }
+
+        public bool CanHandleCtrlBreak { get; set; }
     }
 }


### PR DESCRIPTION
As mentioned in #572, it would be beneficial if service termination via console could handle Ctrl+Break in the same way Ctrl+C.

Main rationale: if a service is running under some sort of orchestrator such as Nomad or even Docker as they send Ctrl+Break, as Ctrl+C signals do not propagate.

This PR adds support for a new `HostConfigurator` item, `EnableHandleCtrlBreak()`, which will ultimately enable the console host to determine if it should terminate hard (if not set), or act similarly to Ctrl+C and gracefully stop (if set).

Feel free to suggest alternate naming if it's not up to scratch!

