### PR TITLE
Log the right framework description

### DIFF
--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -207,8 +207,8 @@ namespace Topshelf.HostConfigurators
         {
             Type type = typeof(HostFactory);
             HostLogger.Get<HostConfiguratorImpl>()
-                .InfoFormat("{0} v{1}, .NET Framework v{2}", type.Namespace, type.Assembly.GetName().Version,
-                    Environment.Version);
+                .InfoFormat("{0} v{1}, {2} ({3})", type.Namespace, type.Assembly.GetName().Version,
+                    RuntimeInformation.FrameworkDescription, Environment.Version);
 
             EnvironmentBuilder environmentBuilder = _environmentBuilderFactory(this);
 

--- a/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
+++ b/src/Topshelf/Configuration/HostConfigurators/HostConfiguratorImpl.cs
@@ -15,6 +15,7 @@ namespace Topshelf.HostConfigurators
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using Builders;
     using CommandLineParser;
     using Configurators;


### PR DESCRIPTION
Use the RuntimeInformation to log the right FrameworkDescription to avoid writing `.NET Framework` when actually running `.NET Core`

Relates to https://github.com/Topshelf/Topshelf/issues/544