### PR TITLE
Upgraded libs, migrate to .net core 3.1, net 5.0

### DIFF
--- a/src/SampleTopshelfService/Program.cs
+++ b/src/SampleTopshelfService/Program.cs
@@ -24,7 +24,7 @@ namespace SampleTopshelfService
                 {
                     Log.Logger = new LoggerConfiguration()
                         .MinimumLevel.Debug()
-                        .WriteTo.ColoredConsole()
+                        .WriteTo.Console()
                         .CreateLogger();
                     x.UseSerilog();
 

--- a/src/SampleTopshelfService/SampleTopshelfService.csproj
+++ b/src/SampleTopshelfService/SampleTopshelfService.csproj
@@ -1,20 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Topshelf.Serilog\Topshelf.Serilog.csproj" />

--- a/src/TopShelf.ServiceInstaller/TopShelf.ServiceInstaller.csproj
+++ b/src/TopShelf.ServiceInstaller/TopShelf.ServiceInstaller.csproj
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="4.7.0" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="5.0.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="5.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Topshelf.Elmah/Topshelf.Elmah.csproj
+++ b/src/Topshelf.Elmah/Topshelf.Elmah.csproj
@@ -16,10 +16,19 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Elmah" Version="1.2.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+  </ItemGroup>
+
+ 
 
   <ItemGroup>
     <ProjectReference Include="..\Topshelf\Topshelf.csproj" />

--- a/src/Topshelf.Extensions.Configuration.Tests/Topshelf.Extensions.Configuration.Tests.csproj
+++ b/src/Topshelf.Extensions.Configuration.Tests/Topshelf.Extensions.Configuration.Tests.csproj
@@ -1,22 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Topshelf\Topshelf.csproj" />
-    <ProjectReference Include="..\Topshelf.Extensions.Configuration\Topshelf.Extensions.Configuration.csproj" />
+    <ProjectReference Include="..\Topshelf.Extensions.Configuration\Topshelf.Extensions.Configuration.csproj" />  
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.2" />
   </ItemGroup>

--- a/src/Topshelf.Extensions.Configuration/Topshelf.Extensions.Configuration.csproj
+++ b/src/Topshelf.Extensions.Configuration/Topshelf.Extensions.Configuration.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/src/Topshelf.Extensions.Logging/Logging/LoggingExtensionsLogWriter.cs
+++ b/src/Topshelf.Extensions.Logging/Logging/LoggingExtensionsLogWriter.cs
@@ -13,8 +13,11 @@
 namespace Topshelf.Logging
 {
     using System;
+    using System.Collections.Generic;
     using Microsoft.Extensions.Logging;
+#if NET452
     using Microsoft.Extensions.Logging.Internal;
+#endif
 
     /// <summary>
     /// Implements a Topshelf <see cref="LogWriter"/> for Microsoft extensions for logging.
@@ -108,13 +111,25 @@ namespace Topshelf.Logging
         /// <param name="args">The arguments.</param>
         public void LogFormat(LoggingLevel level, IFormatProvider formatProvider, string format, params object[] args) => this.LogFormat(level, format, args);
 
+
         /// <summary>
         /// Logs the format.
         /// </summary>
         /// <param name="level">The level.</param>
         /// <param name="format">The format.</param>
         /// <param name="args">The arguments.</param>
+#if NET452
         public void LogFormat(LoggingLevel level, string format, params object[] args) => this.Log(level, new FormattedLogValues(format, args));
+#else
+        public void LogFormat(LoggingLevel level, string format, params object[] args)
+        {
+            var list = new List<KeyValuePair<string, object>>
+            {
+                new (format,args)
+            };
+            this.Log(level, list);
+        }
+#endif
 
         /// <summary>
         /// Debugs the specified object.

--- a/src/Topshelf.Extensions.Logging/Topshelf.Extensions.Logging.csproj
+++ b/src/Topshelf.Extensions.Logging/Topshelf.Extensions.Logging.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/src/Topshelf.NLog/Topshelf.NLog.csproj
+++ b/src/Topshelf.NLog/Topshelf.NLog.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="NLog" Version="4.7.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Topshelf.Tests/Topshelf.Tests.csproj
+++ b/src/Topshelf.Tests/Topshelf.Tests.csproj
@@ -1,16 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Topshelf.sln
+++ b/src/Topshelf.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31815.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topshelf", "Topshelf\Topshelf.csproj", "{A52AD64D-6455-4A22-8CCF-581851086578}"
 EndProject
@@ -25,7 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topshelf.Extensions.Logging
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Topshelf.Extensions.Configuration.Tests", "Topshelf.Extensions.Configuration.Tests\Topshelf.Extensions.Configuration.Tests.csproj", "{98E391A8-3132-4D60-818A-A68A62254068}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TopShelf.ServiceInstaller", "TopShelf.ServiceInstaller\TopShelf.ServiceInstaller.csproj", "{699FB86C-E57F-4750-BE0F-ACDCC3F19364}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TopShelf.ServiceInstaller", "TopShelf.ServiceInstaller\TopShelf.ServiceInstaller.csproj", "{699FB86C-E57F-4750-BE0F-ACDCC3F19364}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Upgraded libs to latest versions.
Remove not supported .net core 2.1 - added 3.1 and 5.0 instead.
Removed deprecated Serilog.Sinks.ColoredConsole - used Serilog.Sinks.Console instead